### PR TITLE
feat-JWT 및 쿠키 기반의 일반/소셜 로그인 기능 구현

### DIFF
--- a/src/main/java/com/sing4u/kr/application/config/SecurityConfig.java
+++ b/src/main/java/com/sing4u/kr/application/config/SecurityConfig.java
@@ -1,8 +1,10 @@
 package com.sing4u.kr.application.config;
 
+import com.sing4u.kr.auth.oauth.service.CustomOAuth2UserService;
+import com.sing4u.kr.auth.oauth.handler.CustomSuccessHandler;
 import com.sing4u.kr.common.properties.CorsProperties;
 import lombok.RequiredArgsConstructor;
-import org.springframework.beans.factory.annotation.Value;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.access.expression.SecurityExpressionHandler;
@@ -14,8 +16,6 @@ import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
 import org.springframework.security.config.http.SessionCreationPolicy;
-import org.springframework.security.crypto.factory.PasswordEncoderFactories;
-import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.FilterInvocation;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.access.expression.DefaultWebSecurityExpressionHandler;
@@ -40,6 +40,7 @@ import com.sing4u.kr.user.enums.UserRole;
 @RequiredArgsConstructor
 @EnableWebSecurity
 @EnableMethodSecurity
+@Slf4j
 public class SecurityConfig {
 
     private final RestAccessDeniedHandler restAccessDeniedHandler;
@@ -47,14 +48,11 @@ public class SecurityConfig {
     private final JwtTokenProvider jwtTokenProvider;
     private final EndPointProperties endPointProperties;
     private final CorsProperties corsProperties;
+    private final CustomOAuth2UserService customOAuth2UserService;
+    private final CustomSuccessHandler customSuccessHandler;
 
 //    @Value("${http.cors.allowedOriginPatterns}")
 //    private String allowedOriginPatterns;
-
-    @Bean
-    public PasswordEncoder passwordEncoder() {
-        return PasswordEncoderFactories.createDelegatingPasswordEncoder();
-    }
 
     @Bean
     public static RoleHierarchy roleHierarchy() {
@@ -99,6 +97,10 @@ public class SecurityConfig {
                 )
                 .sessionManagement(session -> session
                         .sessionCreationPolicy(SessionCreationPolicy.STATELESS)
+                )
+                .oauth2Login(oauth2 -> oauth2
+                        .userInfoEndpoint(userInfo -> userInfo.userService(customOAuth2UserService))
+                        .successHandler(customSuccessHandler)
                 )
                 .formLogin(AbstractHttpConfigurer::disable)
                 .addFilterBefore(jwtTokenFilter(), UsernamePasswordAuthenticationFilter.class)

--- a/src/main/java/com/sing4u/kr/application/config/SwaggerConfig.java
+++ b/src/main/java/com/sing4u/kr/application/config/SwaggerConfig.java
@@ -1,5 +1,6 @@
 package com.sing4u.kr.application.config;
 
+import io.swagger.v3.oas.models.Components;
 import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.info.Info;
 import io.swagger.v3.oas.models.security.*;
@@ -20,27 +21,43 @@ public class SwaggerConfig {
     @Value("${sing4u.server-url}")
     private String serverUrl;
 
+
     @Bean
     public OpenAPI customOpenAPI() {
         return new OpenAPI()
                 .info(new Info().title("Sing4U API").description("Sing4U API").version("v1"))
-                .addServersItem(new Server().url(this.serverUrl))
-                .addSecurityItem(new SecurityRequirement().addList("OAUTH2"))
-                .components(new io.swagger.v3.oas.models.Components()
-                        .addSecuritySchemes("OAUTH2", new SecurityScheme()
-                                .type(SecurityScheme.Type.OAUTH2)
-                                .flows(new OAuthFlows()
-                                        .password(new OAuthFlow()
-                                                .tokenUrl(serverUrl + "/api/v1/swagger/auth")
-                                                .scopes(new Scopes()
-                                                        .addString("read", "read all")
-                                                        .addString("write", "write all")
-                                                )
-                                        )
-                                )
+                .addSecurityItem(new SecurityRequirement().addList("BearerAuth"))
+                .components(new Components()
+                        .addSecuritySchemes("BearerAuth", new SecurityScheme()
+                                .type(SecurityScheme.Type.HTTP)
+                                .scheme("bearer")
+                                .bearerFormat("JWT")
                         )
                 );
     }
+
+
+//    @Bean
+//    public OpenAPI customOpenAPI() {
+//        return new OpenAPI()
+//                .info(new Info().title("Sing4U API").description("Sing4U API").version("v1"))
+//                .addServersItem(new Server().url(this.serverUrl))
+//                .addSecurityItem(new SecurityRequirement().addList("OAUTH2"))
+//                .components(new io.swagger.v3.oas.models.Components()
+//                        .addSecuritySchemes("OAUTH2", new SecurityScheme()
+//                                .type(SecurityScheme.Type.OAUTH2)
+//                                .flows(new OAuthFlows()
+//                                        .password(new OAuthFlow()
+//                                                .tokenUrl(serverUrl + "/api/v1/swagger/auth")
+//                                                .scopes(new Scopes()
+//                                                        .addString("read", "read all")
+//                                                        .addString("write", "write all")
+//                                                )
+//                                        )
+//                                )
+//                        )
+//                );
+//    }
 
     @Bean
     public GroupedOpenApi publicApi() {

--- a/src/main/java/com/sing4u/kr/application/model/DefaultUserDetail.java
+++ b/src/main/java/com/sing4u/kr/application/model/DefaultUserDetail.java
@@ -42,12 +42,12 @@ public class DefaultUserDetail implements UserDetails, Serializable {
 
     @Override
     public boolean isAccountNonLocked() {
-        return false;
+        return true;
     }
 
     @Override
     public boolean isCredentialsNonExpired() {
-        return false;
+        return true; // false에서 true로 변경 자격 증명이 만료되지 않도록 함
     }
 
     @Override

--- a/src/main/java/com/sing4u/kr/application/utils/SecurityContextUtils.java
+++ b/src/main/java/com/sing4u/kr/application/utils/SecurityContextUtils.java
@@ -1,13 +1,12 @@
 package com.sing4u.kr.application.utils;
 
 import lombok.experimental.UtilityClass;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.context.SecurityContextHolder;
-import org.springframework.security.core.userdetails.UserDetails;
-
 
 import java.util.ArrayList;
 import java.util.List;
@@ -20,6 +19,7 @@ import com.sing4u.kr.user.enums.UserRole;
 import static org.apache.commons.collections4.CollectionUtils.emptyIfNull;
 
 @UtilityClass
+@Slf4j
 public class SecurityContextUtils {
     public static void setSecurityContext(Long accountId, List<UserRole> roles) {
         List<GrantedAuthority> authorities = new ArrayList<>();
@@ -28,6 +28,8 @@ public class SecurityContextUtils {
             SimpleGrantedAuthority simpleGrantedAuthority = new SimpleGrantedAuthority(toGrantedAuthority(role));
             authorities.add(simpleGrantedAuthority);
         }
+
+        log.info("setSecurityContext: accountId={}, roles={}", accountId, authorities);
 
         DefaultUserDetail userDetail = DefaultUserDetail.of(accountId, authorities);
 
@@ -42,6 +44,7 @@ public class SecurityContextUtils {
     }
 
     public Long getAccountId(Authentication authentication) {
+
         if (authentication == null) {
             throw new ApiException(ResponseCode.ERROR_NO_AUTHORIZED);
         }
@@ -57,6 +60,16 @@ public class SecurityContextUtils {
     public Long getAccountId() {
         Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
 
-        return getAccountId(authentication);
+        if (authentication == null) {
+            throw new ApiException(ResponseCode.ERROR_NO_AUTHORIZED);
+        }
+
+        if (!DefaultUserDetail.class.isInstance(authentication.getPrincipal())) {
+            throw new ApiException(ResponseCode.ERROR_NO_AUTHORIZED);
+        }
+
+        DefaultUserDetail customUserDetail = DefaultUserDetail.class.cast(authentication.getPrincipal());
+        return customUserDetail.getId();
     }
+
 }

--- a/src/main/java/com/sing4u/kr/auth/config/CookiePropertyInitializer.java
+++ b/src/main/java/com/sing4u/kr/auth/config/CookiePropertyInitializer.java
@@ -1,0 +1,19 @@
+package com.sing4u.kr.auth.config;
+
+import com.sing4u.kr.auth.properties.CookieProperties;
+import com.sing4u.kr.auth.utils.CookieUtils;
+import jakarta.annotation.PostConstruct;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class CookiePropertyInitializer {
+
+    private final CookieProperties cookieProperties;
+    @PostConstruct
+    public void init() {
+        CookieUtils.setCookieProperties(cookieProperties);
+    }
+}
+

--- a/src/main/java/com/sing4u/kr/auth/config/PasswordEncoderConfig.java
+++ b/src/main/java/com/sing4u/kr/auth/config/PasswordEncoderConfig.java
@@ -1,0 +1,15 @@
+package com.sing4u.kr.auth.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.crypto.factory.PasswordEncoderFactories;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+@Configuration
+public class PasswordEncoderConfig {
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return PasswordEncoderFactories.createDelegatingPasswordEncoder();
+    }
+}
+

--- a/src/main/java/com/sing4u/kr/auth/controller/AuthController.java
+++ b/src/main/java/com/sing4u/kr/auth/controller/AuthController.java
@@ -9,20 +9,13 @@ import com.sing4u.kr.auth.service.AuthService;
 import com.sing4u.kr.auth.utils.CookieUtils;
 import com.sing4u.kr.common.dto.ResponseResult;
 import com.sing4u.kr.common.enums.ResponseCode;
-import com.sing4u.kr.jwt.exceptions.InvalidTokenException;
-import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
-import org.springframework.beans.factory.annotation.Value;
-import org.springframework.http.HttpHeaders;
-import org.springframework.http.ResponseCookie;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
-
-import java.time.Duration;
 
 @RestController
 @RequestMapping("/api/v1/auth")
@@ -36,6 +29,7 @@ public class AuthController {
                                                     HttpServletResponse response) {
         LoginDto dto = authService.emailLogin(request);
         CookieUtils.setRefreshTokenCookie(response, dto.getRefreshToken());
+        CookieUtils.setAccessTokenCookie(response, dto.getAccessToken());
 
         return new ResponseResult<>(ResponseCode.SUCCESS, LoginResponse.of(dto.getAccessToken(), dto.getProfileImage()));
     }

--- a/src/main/java/com/sing4u/kr/auth/dto/CustomUserPrincipal.java
+++ b/src/main/java/com/sing4u/kr/auth/dto/CustomUserPrincipal.java
@@ -1,0 +1,84 @@
+package com.sing4u.kr.auth.dto;
+
+import com.sing4u.kr.user.entity.enums.UserType;
+import com.sing4u.kr.user.enums.UserRole;
+import lombok.Getter;
+import com.sing4u.kr.user.entity.User;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Map;
+
+// UserDetails와 OAuth2User를 모두 구현하여 일반/소셜 로그인에 공통으로 사용
+@Getter
+public class CustomUserPrincipal implements UserDetails, OAuth2User {
+
+    private final User user;
+    private Map<String, Object> attributes; // OAuth2 로그인 시 사용
+
+    // 일반 로그인을 위한 생성자
+    public CustomUserPrincipal(User user) {
+        this.user = user;
+    }
+
+    // OAuth2 로그인을 위한 추가 생성자
+    public CustomUserPrincipal(User user, Map<String, Object> attributes) {
+        this.user = user;
+        this.attributes = attributes;
+    }
+
+//    // 이 생성자는 User 엔티티를 직접 받지 않고, 필요한 정보만 받음.
+//    public CustomUserPrincipal(Long userId, String role) {
+//        // 내부적으로 최소한의 정보만 가진 User 객체를 생성
+//        // 이 User 객체는 DB와 연동(영속성)되지 않은, 순수한 데이터 전달용 객체
+//        this.user = User.testUserBuilder(userId, null, null); // User 엔티티의 testUserBuilder 활용
+//        this.user.setRole(UserRole.valueOf(role)); // 역할 설정
+//    }
+
+    @Override
+    public Map<String, Object> getAttributes() { return attributes; }
+
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        Collection<GrantedAuthority> collection = new ArrayList<>();
+//        collection.add(() -> user.getRole().name()); // .name()으로 enum의 문자열 이름을 가져온다.
+        collection.add(new SimpleGrantedAuthority("ROLE_" + user.getRole().name()));
+        return collection;
+    }
+
+    @Override
+    public String getPassword() { return user.getPassword(); }
+
+    // Spring Security에서 username은 고유 식별자여야 함. email을 사용
+    @Override
+    public String getUsername() { return user.getEmail(); }
+
+    // OAuth2 표준의 name 속성.  사용자의 실제 이름을 반환
+    @Override
+    public String getName() { return user.getNickname(); }
+
+    // 우리 시스템 내부에서 사용할 userId를 가져오는 커스텀 메소드
+    public Long getUserId() { return user.getId();}
+
+    public String getNickname() {
+        return user.getNickname();
+    }
+
+    public UserType getUserType() {
+        return user.getUserType();
+    }
+
+    // UserDetails 구현
+    @Override
+    public boolean isAccountNonExpired() { return true; }
+    @Override
+    public boolean isAccountNonLocked() { return true; }
+    @Override
+    public boolean isCredentialsNonExpired() { return true; }
+    @Override
+    public boolean isEnabled() { return user.getDeletedAt() == null; } // soft-delete 고려
+}

--- a/src/main/java/com/sing4u/kr/auth/entity/RefreshToken.java
+++ b/src/main/java/com/sing4u/kr/auth/entity/RefreshToken.java
@@ -1,4 +1,4 @@
-package com.sing4u.kr.auth.Entity;
+package com.sing4u.kr.auth.entity;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -23,7 +23,7 @@ public class RefreshToken {
     @Column(nullable = false)
     private Long userId;
 
-    @Column(nullable = false)
+    @Column(nullable = false, length = 1000)
     private String token;
 
     @CreationTimestamp

--- a/src/main/java/com/sing4u/kr/auth/oauth/dto/GoogleUserInfo.java
+++ b/src/main/java/com/sing4u/kr/auth/oauth/dto/GoogleUserInfo.java
@@ -1,0 +1,33 @@
+package com.sing4u.kr.auth.oauth.dto;
+
+import java.util.Map;
+
+public class GoogleUserInfo implements OAuth2UserInfo {
+
+    private final Map<String, Object> attributes;
+
+    public GoogleUserInfo(Map<String, Object> attributes) {
+        this.attributes = attributes;
+    }
+
+    @Override
+    public String getProvider() {
+        return "google";
+    }
+
+    @Override
+    public String getProviderId() {
+        return attributes.get("sub").toString();
+    }
+
+    @Override
+    public String getEmail() {
+        return attributes.get("email").toString();
+    }
+
+    @Override
+    public String getName() {
+        return attributes.get("name").toString();
+    }
+}
+

--- a/src/main/java/com/sing4u/kr/auth/oauth/dto/NaverUserInfo.java
+++ b/src/main/java/com/sing4u/kr/auth/oauth/dto/NaverUserInfo.java
@@ -1,0 +1,33 @@
+package com.sing4u.kr.auth.oauth.dto;
+
+import java.util.Map;
+
+public class NaverUserInfo implements OAuth2UserInfo {
+
+    private final Map<String, Object> attributes;
+
+    public NaverUserInfo(Map<String, Object> attributes) {
+        this.attributes = (Map<String, Object>) attributes.get("response");
+    }
+
+
+    @Override
+    public String getProvider() {
+        return "naver";
+    }
+
+    @Override
+    public String getProviderId() {
+        return attributes.get("id").toString();
+    }
+
+    @Override
+    public String getEmail() {
+        return attributes.get("email").toString();
+    }
+
+    @Override
+    public String getName() {
+        return attributes.get("name").toString();
+    }
+}

--- a/src/main/java/com/sing4u/kr/auth/oauth/dto/OAuth2UserInfo.java
+++ b/src/main/java/com/sing4u/kr/auth/oauth/dto/OAuth2UserInfo.java
@@ -1,0 +1,17 @@
+package com.sing4u.kr.auth.oauth.dto;
+
+public interface OAuth2UserInfo {
+
+    //제공자 (ex.. naver, google)
+    String getProvider();
+
+    //제공자에서 발급해주는 아이디(번호)
+    String getProviderId();
+    //이메일
+
+    String getEmail();
+
+    //사용자 실명 (설정한 이름)
+    String getName();
+}
+

--- a/src/main/java/com/sing4u/kr/auth/oauth/handler/CustomSuccessHandler.java
+++ b/src/main/java/com/sing4u/kr/auth/oauth/handler/CustomSuccessHandler.java
@@ -1,0 +1,61 @@
+package com.sing4u.kr.auth.oauth.handler;
+
+import com.sing4u.kr.auth.utils.CookieUtils;
+import com.sing4u.kr.auth.dto.CustomUserPrincipal;
+import com.sing4u.kr.auth.entity.RefreshToken;
+import com.sing4u.kr.auth.repository.RefreshTokenRepository;
+import com.sing4u.kr.jwt.provider.JwtTokenProvider;
+import com.sing4u.kr.user.entity.enums.UserType;
+import com.sing4u.kr.user.enums.UserRole;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.web.authentication.SimpleUrlAuthenticationSuccessHandler;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.io.IOException;
+import java.util.List;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class CustomSuccessHandler extends SimpleUrlAuthenticationSuccessHandler {
+
+    private final JwtTokenProvider jwtTokenProvider;
+    private final RefreshTokenRepository refreshTokenRepository;
+
+    @Value("${sing4u.oauth-redirect-url}")
+    private String redirectUrl;
+
+    @Override
+    @Transactional
+    public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response, Authentication authentication) throws IOException, ServletException {
+        CustomUserPrincipal principal = (CustomUserPrincipal) authentication.getPrincipal();
+
+        Long userId = principal.getUserId();
+        String role = principal.getAuthorities().iterator().next().getAuthority();
+        String nickname = principal.getNickname();
+
+        // Access Token과 Refresh Token 생성 (userId 기반)
+        List<UserRole> roles = List.of(UserRole.valueOf(role));
+        String accessToken = jwtTokenProvider.generateAccessToken(userId, roles, nickname);
+        String refreshToken = jwtTokenProvider.generateRefreshToken(userId, roles, nickname);
+
+        // Refresh Token을 DB에 저장
+        refreshTokenRepository.save(RefreshToken.of(userId, refreshToken));
+
+        // Access Token은 쿠키에 담아서 프론트로 전달 (토큰 교환용)
+        CookieUtils.setAccessTokenCookie(response, accessToken);
+        // Refresh Token도 별도 쿠키로 전달 (재발급용)
+        CookieUtils.setRefreshTokenCookie(response, refreshToken);
+
+        // 프론트의 특정 콜백 URL로 리디렉션
+        getRedirectStrategy().sendRedirect(request, response, redirectUrl);
+    }
+
+}

--- a/src/main/java/com/sing4u/kr/auth/oauth/service/CustomOAuth2UserService.java
+++ b/src/main/java/com/sing4u/kr/auth/oauth/service/CustomOAuth2UserService.java
@@ -1,0 +1,61 @@
+package com.sing4u.kr.auth.oauth.service;
+
+import com.sing4u.kr.auth.dto.CustomUserPrincipal;
+import com.sing4u.kr.auth.oauth.dto.GoogleUserInfo;
+import com.sing4u.kr.auth.oauth.dto.OAuth2UserInfo;
+import com.sing4u.kr.user.entity.User;
+import com.sing4u.kr.user.entity.enums.SocialType;
+import com.sing4u.kr.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.crypto.password.PasswordEncoder; // PasswordEncoder import
+import org.springframework.security.oauth2.client.userinfo.DefaultOAuth2UserService;
+import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest;
+import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class CustomOAuth2UserService extends DefaultOAuth2UserService {
+
+    private final UserRepository userRepository;
+    private final PasswordEncoder passwordEncoder; // 비밀번호 암호화기 주입
+
+    @Override
+    @Transactional
+    public OAuth2User loadUser(OAuth2UserRequest userRequest) throws OAuth2AuthenticationException {
+        OAuth2User oAuth2User = super.loadUser(userRequest);
+        log.info("oAuth2User : "+ oAuth2User);
+        String registrationId = userRequest.getClientRegistration().getRegistrationId();
+
+        OAuth2UserInfo oAuth2Response;
+        if(registrationId.equals("google")) {
+            oAuth2Response = new GoogleUserInfo(oAuth2User.getAttributes());
+        } else{
+            // 다른 소셜 로그인 추가 시 여기에 구현
+            throw new OAuth2AuthenticationException("Unsupported provider : " + registrationId);
+        }
+
+        User user = userRepository.findByEmailAndDeletedAtIsNull(oAuth2Response.getEmail())
+                .orElseGet(() -> {
+                    // 새로운 사용자일 경우 DB에 저장.
+                    // 소셜 로그인 사용자는 비밀번호가 없으므로, 임의의 값을 암호화하여 저장.
+                    String randomPassword = passwordEncoder.encode(java.util.UUID.randomUUID().toString());
+                    return userRepository.save(
+                            User.ofOAuth2(
+                                    oAuth2Response.getEmail(),
+                                    oAuth2Response.getName(),
+                                    randomPassword,
+                                    SocialType.valueOf(registrationId.toUpperCase())
+                            )
+                    );
+                });
+
+        userRepository.save(user);
+
+        return new CustomUserPrincipal(user, oAuth2User.getAttributes());
+    }
+}

--- a/src/main/java/com/sing4u/kr/auth/properties/CookieProperties.java
+++ b/src/main/java/com/sing4u/kr/auth/properties/CookieProperties.java
@@ -10,10 +10,19 @@ import org.springframework.stereotype.Component;
 @Component
 @ConfigurationProperties(prefix = "cookie")
 public class CookieProperties {
+    // Refresh Token 설정
     private String refreshName;
     private String refreshPath;
     private boolean refreshHttpOnly;
     private boolean refreshSecure;
     private String refreshSameSite;
     private int refreshMaxAgeDays;
+
+    // Access Token 설정
+    private String accessName;
+    private String accessPath;
+    private boolean accessHttpOnly;
+    private boolean accessSecure;
+    private String accessSameSite;
+    private int accessMaxAgeMinutes;
 }

--- a/src/main/java/com/sing4u/kr/auth/repository/RefreshTokenRepository.java
+++ b/src/main/java/com/sing4u/kr/auth/repository/RefreshTokenRepository.java
@@ -1,7 +1,16 @@
 package com.sing4u.kr.auth.repository;
 
-import com.sing4u.kr.auth.Entity.RefreshToken;
+import com.sing4u.kr.auth.entity.RefreshToken;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface RefreshTokenRepository extends JpaRepository<RefreshToken, Long> {
+
+    // 토큰 값으로 RefreshToken을 찾는 메서드
+    Optional<RefreshToken> findByToken(String token);
+
+    // 토큰 값으로 RefreshToken을 삭제하는 메서드
+    void deleteByToken(String token);
+
 }

--- a/src/main/java/com/sing4u/kr/auth/service/AuthService.java
+++ b/src/main/java/com/sing4u/kr/auth/service/AuthService.java
@@ -1,6 +1,6 @@
 package com.sing4u.kr.auth.service;
 
-import com.sing4u.kr.auth.Entity.RefreshToken;
+import com.sing4u.kr.auth.entity.RefreshToken;
 import com.sing4u.kr.auth.dto.LoginDto;
 import com.sing4u.kr.auth.dto.request.LoginRequest;
 import com.sing4u.kr.auth.dto.response.TokenDto;
@@ -11,6 +11,8 @@ import com.sing4u.kr.jwt.exceptions.InvalidTokenException;
 import com.sing4u.kr.jwt.model.JwtToken;
 import com.sing4u.kr.jwt.provider.JwtTokenProvider;
 import com.sing4u.kr.user.entity.User;
+import com.sing4u.kr.user.entity.enums.UserType;
+import com.sing4u.kr.user.enums.UserRole;
 import com.sing4u.kr.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -43,15 +45,13 @@ public class AuthService {
         String accessToken = jwtTokenProvider.generateAccessToken(
                 user.getId(),
                 List.of(user.getRole()),
-                user.getNickname(),
-                user.getUserType()
+                user.getNickname()
         );
 
         String refreshTokenValue = jwtTokenProvider.generateRefreshToken(
                 user.getId(),
                 List.of(user.getRole()),
-                user.getNickname(),
-                user.getUserType()
+                user.getNickname()
         );
 
         refreshTokenRepository.save(RefreshToken.of(user.getId(), refreshTokenValue));
@@ -60,6 +60,8 @@ public class AuthService {
 
     @Transactional
     public TokenDto refresh(String refreshToken) {
+        // 전체적인 재발급 로직 변경 (Refresh Token Rotaion 적용)
+        // 1. 요청으로 받은 Refresh Token 유효성 검증
         JwtToken jwt;
         try {
             jwt = jwtTokenProvider.getAllClaimsFromToken(refreshToken);
@@ -67,27 +69,32 @@ public class AuthService {
             throw new InvalidTokenException();
         }
 
-        RefreshToken storedToken = refreshTokenRepository.findById(jwt.getUserId())
-                .orElseThrow(InvalidTokenException::new);
+        // 2. DB에서 해당 Refresh Token 조회
+        RefreshToken storedToken = refreshTokenRepository.findByToken(refreshToken)
+                .orElseThrow(() -> {
+                    // DB에 토큰이 없다는 것은 이미 사용되었거나 탈취 후 삭제되었을 가능성이 있음
+                    // 로그를 남기고 예외 처리
+                    log.warn("Invalid or already used refresh token: {}", refreshToken);
+                    return new InvalidTokenException();
+                });
 
-        String newRefreshToken = refreshToken;
-        if (jwt.getExpiredAt().before(new Date())) {
-            newRefreshToken = jwtTokenProvider.generateRefreshToken(
-                    jwt.getUserId(),
-                    jwt.getRoles(),
-                    jwt.getNickName(),
-                    jwt.getUserType()
-            );
-            storedToken.update(newRefreshToken);
-            refreshTokenRepository.save(storedToken);
-        }
+        // 3. 기존 Refresh Token을 DB에서 삭제 (재사용 방지)
+        refreshTokenRepository.deleteByToken(refreshToken);
 
+        // 4. 새로운 Access Token과 Refresh Token 생성
         String newAccessToken = jwtTokenProvider.generateAccessToken(
                 jwt.getUserId(),
                 jwt.getRoles(),
-                jwt.getNickName(),
-                jwt.getUserType()
+                jwt.getNickName()
         );
+        String newRefreshToken = jwtTokenProvider.generateRefreshToken(
+                jwt.getUserId(),
+                jwt.getRoles(),
+                jwt.getNickName()
+        );
+
+        // 5. 새로 생성된 Refresh Token을 DB에 저장
+        refreshTokenRepository.save(RefreshToken.of(jwt.getUserId(), newRefreshToken));
 
         return TokenDto.of(newAccessToken, newRefreshToken);
     }

--- a/src/main/java/com/sing4u/kr/auth/utils/CookieUtils.java
+++ b/src/main/java/com/sing4u/kr/auth/utils/CookieUtils.java
@@ -1,13 +1,9 @@
 package com.sing4u.kr.auth.utils;
 
 import com.sing4u.kr.auth.properties.CookieProperties;
-import com.sing4u.kr.jwt.exceptions.InvalidTokenException;
-import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
-import lombok.RequiredArgsConstructor;
 import lombok.experimental.UtilityClass;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.ResponseCookie;
 
@@ -18,16 +14,27 @@ public class CookieUtils {
 
     static CookieProperties cookieProperties;
 
-    public static String extractRefreshTokenFromCookie(HttpServletRequest request) {
-        Cookie[] cookies = request.getCookies();
-        if (cookies != null) {
-            for (Cookie cookie : cookies) {
-                if (cookieProperties.getRefreshName().equals(cookie.getName())) {
+    public static void setCookieProperties(CookieProperties properties) {
+        cookieProperties = properties;
+    }
+
+    public String extractRefreshTokenFromCookie(HttpServletRequest request) {
+        return extractTokenFromCookie(request, cookieProperties.getRefreshName());
+    }
+
+    public String extractAccessTokenFromCookie(HttpServletRequest request) {
+        return extractTokenFromCookie(request, cookieProperties.getAccessName());
+    }
+
+    private String extractTokenFromCookie(HttpServletRequest request, String cookieName) {
+        if (request.getCookies() != null) {
+            for (var cookie : request.getCookies()) {
+                if (cookieName.equals(cookie.getName())) {
                     return cookie.getValue();
                 }
             }
         }
-        throw new InvalidTokenException();
+        return null;
     }
 
     public static void setRefreshTokenCookie(HttpServletResponse response, String refreshToken) {
@@ -39,6 +46,18 @@ public class CookieUtils {
                 .maxAge(Duration.ofDays(cookieProperties.getRefreshMaxAgeDays()))
                 .build();
 
-        response.setHeader(HttpHeaders.SET_COOKIE, cookie.toString());
+        response.addHeader(HttpHeaders.SET_COOKIE, cookie.toString());
+    }
+
+    public void setAccessTokenCookie(HttpServletResponse response, String accessToken) {
+        ResponseCookie cookie = ResponseCookie.from(cookieProperties.getAccessName(), accessToken)
+                .httpOnly(cookieProperties.isAccessHttpOnly())
+                .secure(cookieProperties.isAccessSecure())
+                .sameSite(cookieProperties.getAccessSameSite())
+                .path(cookieProperties.getAccessPath())
+                .maxAge(Duration.ofMinutes(cookieProperties.getAccessMaxAgeMinutes()))
+                .build();
+
+        response.addHeader(HttpHeaders.SET_COOKIE, cookie.toString());
     }
 }

--- a/src/main/java/com/sing4u/kr/health/service/SwaggerService.java
+++ b/src/main/java/com/sing4u/kr/health/service/SwaggerService.java
@@ -1,6 +1,7 @@
 package com.sing4u.kr.health.service;
 
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.StringUtils;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
@@ -22,6 +23,7 @@ import static com.sing4u.kr.common.enums.ResponseCode.ERROR_USER_NOT_FOUND;
 
 @Service
 @RequiredArgsConstructor
+@Slf4j
 public class SwaggerService {
     @Value("${spring.profiles.active}")
     private String activeProfile;
@@ -48,18 +50,16 @@ public class SwaggerService {
         }
 
         String[] type = StringUtils.split(username, "_");
-        UserType userType = UserType.toUserType(type[0]);
         UserRole mainRole = UserRole.getMainAccountRoleFromString(List.of(type[0]));
         Long accountId = Long.parseLong(type[1]);
-
+        log.info("accountId : " + accountId);
         User user = this.userRepository.findByIdAndDeletedAtIsNull(accountId)
                 .orElseThrow(() -> new Exception400(ERROR_USER_NOT_FOUND));
 
         String accessToken = jwtTokenProvider.generateAccessToken(
                 user.getId(),
                 List.of(mainRole),
-                user.getNickname(),
-                userType
+                user.getNickname()
         );
 
         return SwaggerAuthResponse.of(

--- a/src/main/java/com/sing4u/kr/jwt/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/com/sing4u/kr/jwt/filter/JwtAuthenticationFilter.java
@@ -1,5 +1,6 @@
 package com.sing4u.kr.jwt.filter;
 
+import com.sing4u.kr.auth.utils.CookieUtils;
 import io.jsonwebtoken.ExpiredJwtException;
 import io.jsonwebtoken.MalformedJwtException;
 import io.jsonwebtoken.SignatureException;
@@ -11,9 +12,7 @@ import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.StringUtils;
-import org.springframework.http.HttpHeaders;
 import org.springframework.web.filter.OncePerRequestFilter;
-
 
 import java.io.IOException;
 
@@ -36,7 +35,13 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
             throws ServletException, IOException {
 
-        String accessToken = getAccessTokenFromHeader(request);
+        String path = request.getRequestURI();
+        if (path.startsWith("/api/v1/auth/login")) {
+            filterChain.doFilter(request, response);
+            return;  // 로그인 요청은 토큰 검사 스킵
+        }
+
+        String accessToken =  CookieUtils.extractAccessTokenFromCookie(request);
 
         if (StringUtils.isBlank(accessToken)) {
             filterChain.doFilter(request, response);
@@ -49,8 +54,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
         } catch (ExpiredJwtException e) {
             response.setHeader(HEADER_EXCEPTION_CODE, ERROR_EXPIRED_TOKEN.getCode());
             throw new ExpiredTokenException();
-        } catch (UnsupportedJwtException | MalformedJwtException | SignatureException | IllegalArgumentException |
-                 InvalidTokenException e) {
+        } catch (UnsupportedJwtException | MalformedJwtException | SignatureException | IllegalArgumentException e) {
             response.setHeader(HEADER_EXCEPTION_CODE, ERROR_INVALID_TOKEN.getCode());
             log.error("invalid token exception, request uri : {}, accessToken : {}", request.getRequestURI(), accessToken);
             throw new InvalidTokenException(e.getMessage());
@@ -59,11 +63,11 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
         filterChain.doFilter(request, response);
     }
 
-    private String getAccessTokenFromHeader(HttpServletRequest request) {
-        String bearer = request.getHeader(HttpHeaders.AUTHORIZATION);
-        if (bearer != null && bearer.startsWith("Bearer ")) {
-            return StringUtils.replaceIgnoreCase(bearer, "bearer", "").trim();
-        }
-        return null;
-    }
+//    private String getAccessTokenFromHeader(HttpServletRequest request) {
+//        String bearer = request.getHeader(HttpHeaders.AUTHORIZATION);
+//        if (bearer != null && bearer.startsWith("Bearer ")) {
+//            return StringUtils.replaceIgnoreCase(bearer, "bearer", "").trim();
+//        }
+//        return null;
+//    }
 }

--- a/src/main/java/com/sing4u/kr/jwt/model/JwtToken.java
+++ b/src/main/java/com/sing4u/kr/jwt/model/JwtToken.java
@@ -21,5 +21,4 @@ public class JwtToken {
     private List<UserRole> roles;
     private String nickName;
     private String userName;
-    private UserType userType;
 }

--- a/src/main/java/com/sing4u/kr/jwt/provider/JwtTokenProvider.java
+++ b/src/main/java/com/sing4u/kr/jwt/provider/JwtTokenProvider.java
@@ -1,32 +1,28 @@
 package com.sing4u.kr.jwt.provider;
 
+import com.sing4u.kr.common.utils.DataUtils;
+import com.sing4u.kr.user.entity.enums.UserType;
 import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.Header;
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.SignatureAlgorithm;
 import io.jsonwebtoken.security.Keys;
 import jakarta.annotation.PostConstruct;
-import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.security.oauth2.jwt.JwtException;
 import org.springframework.stereotype.Component;
-
 
 import java.security.Key;
 import java.time.ZonedDateTime;
 import java.util.*;
 import java.util.stream.Collectors;
 
-import com.sing4u.kr.common.utils.DataUtils;
 import com.sing4u.kr.jwt.model.JwtToken;
-import com.sing4u.kr.user.entity.enums.UserType;
 import com.sing4u.kr.user.enums.UserRole;
 
 @Component
 @Slf4j
 public class JwtTokenProvider {
-
 
     @Value("${jwt.secret}")
     private String secret;
@@ -38,7 +34,6 @@ public class JwtTokenProvider {
     private long refreshTokenValidity;
 
     private final String ACCOUNT_ID = "accountId";
-    private final String USER_TYPE = "user_type";
     private final String USER_NAME = "user_name";
     private final String NICK_NAME = "nick_name";
     private static final String AUTHORITIES = "authorities";
@@ -60,11 +55,10 @@ public class JwtTokenProvider {
 
     public String generateAccessToken(Long accountId,
                                       List<UserRole> roles,
-                                      String nickName,
-                                      UserType userType) {
+                                      String nickName) {
         ZonedDateTime now = ZonedDateTime.now();
 
-        Map<String, Object> claims = getClaimsForCreation(accountId, roles, nickName, userType);
+        Map<String, Object> claims = getClaimsForCreation(accountId, roles, nickName);
 
         ZonedDateTime expiration = now.plusSeconds(accessTokenValidity);
         Date expirationDate = Date.from(expiration.toInstant());
@@ -74,15 +68,13 @@ public class JwtTokenProvider {
 
     private Map<String, Object> getClaimsForCreation(Long accountId,
                                                      List<UserRole> roles,
-                                                     String nickName,
-                                                     UserType userType) {
+                                                     String nickName) {
 
         Map<String, Object> claims = new HashMap<>();
         claims.put(ACCOUNT_ID, accountId);
         claims.put(AUTHORITIES, roles);
         claims.put(USER_NAME, getUserName(roles, accountId));
         claims.put(NICK_NAME, nickName);
-        claims.put(USER_TYPE, userType);
         return claims;
     }
 
@@ -93,16 +85,24 @@ public class JwtTokenProvider {
                 .parseClaimsJws(token)
                 .getBody();
 
-        List<UserRole> roles = DataUtils.cast(claims.get(AUTHORITIES, List.class), UserRole.class);
-        UserType userType = UserType.valueOf(claims.get(USER_TYPE, String.class));
+
+//        List<UserRole> roles = DataUtils.cast(claims.get(AUTHORITIES, List.class), UserRole.class);
+        // 1. 토큰에서 문자열 리스트를 가져옵니다.
+        List<String> roleStrings = claims.get(AUTHORITIES, List.class);
+
+//        UserType userType = UserType.valueOf(claims.get(USER_TYPE, String.class));
+
+//        // 2. 각 문자열을 UserRole Enum으로 변환하여 새로운 리스트를 만듭니다.
+        List<UserRole> roles = roleStrings.stream()
+                .map(UserRole::valueOf)
+                .collect(Collectors.toList());
 
         return JwtToken.of(
                 claims.get(ACCOUNT_ID, Long.class),
                 claims.getExpiration(),
                 roles,
                 claims.get(NICK_NAME, String.class),
-                claims.get(USER_NAME, String.class),
-                userType
+                claims.get(USER_NAME, String.class)
         );
 
     }
@@ -123,11 +123,10 @@ public class JwtTokenProvider {
 
     public String generateRefreshToken(Long accountId,
                                       List<UserRole> roles,
-                                      String nickName,
-                                      UserType userType) {
+                                      String nickName) {
         ZonedDateTime now = ZonedDateTime.now();
 
-        Map<String, Object> claims = getClaimsForCreation(accountId, roles, nickName, userType);
+        Map<String, Object> claims = getClaimsForCreation(accountId, roles, nickName);
 
         ZonedDateTime expiration = now.plusSeconds(refreshTokenValidity);
         Date expirationDate = Date.from(expiration.toInstant());

--- a/src/main/java/com/sing4u/kr/user/entity/User.java
+++ b/src/main/java/com/sing4u/kr/user/entity/User.java
@@ -73,11 +73,22 @@ public class User {
     private boolean isOpen;
 
     public static User of(String nickname, String email, String password, UserType userType) {
+
+        UserRole role;
+        if (UserType.ARTIST.equals(userType)) {
+            role = UserRole.ARTIST;
+        } else if(UserType.USER.equals(userType)) {
+            role = UserRole.USER;
+        } else {
+            role = UserRole.ADMIN;
+        }
+
         return User.builder()
                 .nickname(nickname)
                 .email(email)
                 .password(password)
                 .userType(userType)
+                .role(role)
                 .isOpen(false)
                 .build();
     }
@@ -123,5 +134,15 @@ public class User {
                 .userType(userType)
                 .build();
 
+    }
+    public static User ofOAuth2(String email, String name, String encodedPassword, SocialType socialType) {
+        return User.builder()
+                .email(email)
+                .nickname(name)
+                .password(encodedPassword)
+                .role(UserRole.USER)
+                .userType(UserType.USER)
+                .socialType(socialType)
+                .build();
     }
 }

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -37,6 +37,22 @@ spring:
     show-sql: true
     open-in-view: false
 
+  security:
+    oauth2:
+      client:
+        registration:
+          google:
+            client-id: 539834899906-k6coqhv9e97j81ep76e92883nhptcu1v.apps.googleusercontent.com #${GOOGLE_CLIENT_ID}
+            client-secret: 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 #${GOOGLE_CLIENT_SECRET}
+            scope:
+              - profile
+              - email
+  #      provider:  구굴의 경우 OAuth2 Provider가 Spring Security 내장되어있음
+  #        google:
+  #          authorization-uri: https://accounts.google.com/o/oauth2/auth
+  #          token-uri: https://oauth2.googleapis.com/token
+  #          user-info-uri: https://www.googleapis.com/oauth2/v3/userinfo
+
 endpoints:
   public-api-list:
     - /api/v1/health/**
@@ -49,17 +65,44 @@ endpoints:
     - /v3/api-docs
     - /api/v1/users/register
     - /api/v1/home
-
+    - /api/v1/auth/login/oauth/token
+    - /v3/api-docs/**
+    - /api/v1/auth/login/**
+    - /api/v1/swagger/auth
+    - /api/v1/auth/refresh
 
 sing4u:
-  server-url: http://localhost:8080
+#  server-url: http://localhost:8080
+  server-url: http://13.125.210.40:8080
   file-url: https://image.sing4u.kr/
+  oauth-redirect-url: http://localhost:3000/auth/callback
 
 cors:
   origin:
     - "*"
 
-
 springdoc:
   swagger-ui:
     enabled: true
+
+jwt:
+  issuer: sing4uproject@gmail.com
+  secret: vmfhaltmskdlstkfkdgodyroqkfwkdbalroqkfwkdbalaaaaaaaaaaaaaaaabbbbb #${JWT_SECRET}
+  access-token-validity: 3600000
+  refresh-token-validity: 1209600000
+
+
+cookie:
+  refresh-name: refreshToken
+  refresh-path: /api/v1/auth/recreate
+  refresh-http-only: true
+  refresh-secure: false
+  refresh-same-site: None
+  refresh-max-age-days: 7
+
+  access-name: accessToken
+  access-path: /
+  access-http-only: true
+  access-secure: false
+  access-same-site: Lax
+  access-max-age-minutes: 60

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -1,6 +1,6 @@
 spring:
   datasource:
-    url: jdbc:mysql://${DB_HOST}:${DB_PORT}/${DB_NAME}?useSSL=false&serverTimezone=UTC
+    url: jdbc:mysql://${DB_HOST}:${DB_PORT}/${DB_NAME}?useSSL=false&serverTimezone=UTC&allowPublicKeyRetrieval=true
     username: ${DB_USER}
     password: ${DB_PASS}
     hikari:
@@ -64,6 +64,22 @@ cors:
 springdoc:
   swagger-ui:
     enabled: true
+
+
+cookie:
+  refresh-name: refreshToken
+  refresh-path: /api/v1/auth/recreate
+  refresh-http-only: true
+  refresh-secure: false
+  refresh-same-site: None
+  refresh-max-age-days: 7
+
+  access-name: accessToken
+  access-path: /
+  access-http-only: true
+  access-secure: false
+  access-same-site: Lax
+  access-max-age-minutes: 60
 
 
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -53,6 +53,13 @@ cookie:
   refresh-same-site: None
   refresh-max-age-days: 7
 
+  access-name: accessToken
+  access-path: /
+  access-http-only: true
+  access-secure: true
+  access-same-site: Lax
+  access-max-age-minutes: 60
+
 spotify:
   api:
     client-id: 937b827c270c4a59a3898de109c4c4cd

--- a/src/main/resources/import.sql
+++ b/src/main/resources/import.sql
@@ -1,0 +1,3 @@
+INSERT INTO sing4u.`user`
+(id, created_at, deleted_at, email, introduction, main_cover_url, nickname, password, profile_image, `role`, social_type, updated_at, account_type)
+VALUES(1, NULL, NULL, 'test@naver.com', NULL, NULL, 'user_1', 'user_1', NULL, 'USER', 'GOOGLE', NULL, 'USER');

--- a/src/test/java/com/sing4u/kr/user/service/encodeTest.java
+++ b/src/test/java/com/sing4u/kr/user/service/encodeTest.java
@@ -1,0 +1,20 @@
+package com.sing4u.kr.user.service;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.security.crypto.factory.PasswordEncoderFactories;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+public class encodeTest {
+
+    @Test
+    void encodeTest() {
+        PasswordEncoder passwordEncoder = PasswordEncoderFactories.createDelegatingPasswordEncoder();
+
+        String rawPassword = "user_1";
+        String encodedPassword = passwordEncoder.encode(rawPassword);
+
+        System.out.println(encodedPassword);  // 이미 prefix 포함됨: {bcrypt}...
+    }
+}


### PR DESCRIPTION
## 📄 요약 (Summary)

JWT와 HttpOnly 쿠키를 기반으로 안전한 인증 시스템을 구현.
이번 변경으로 사용자들은 이메일을 이용한 일반 로그인과 Google 계정을 이용한 소셜 로그인 사용


## 🔨 주요 변경 사항 (Key Changes)

### 1. 기존 기능
- **일반 로그인**: 이메일/패스워드 기반의 로그인 기능

### 2. 신규 기능 구현
- **소셜 로그인**: Google OAuth2를 연동하여 소셜 로그인 기능을 구현
- **인증 방식**:
    - 로그인 성공 시, 서버는 **Access Token**과 **Refresh Token**을 JWT 형식으로 발급
    - 발급된 토큰은 XSS 공격 방어를 위해 **`HttpOnly`, `Secure` 속성을 적용한 쿠키**에 담아 클라이언트에 전달
    - 토큰 탈취에 대응하기 위해 **Refresh Token Rotation** 전략 적용

### 3. 리팩토링 및 수정
- **인증 필터 로직 수정**: 설계였던 Authorization 헤더 방식에서, 보안성과 프론트엔드 개발 편의성을 높이기 위해 HttpOnly 쿠키를 읽어 인증하는 방식

## 🧪 테스트 방법 (How to Test)

Postman(또는 Swagger)과 실제 프론트엔드 애플리케이션을 통해 테스트할 수 있습니다.

### 1. 일반 로그인 (Postman/Swagger)
1. `POST /api/v1/auth/login/email` 엔드포인트로 실제 가입된 유저의 이메일/비밀번호를 담아 요청
2. 응답 헤더에 `Set-Cookie`로 `accessToken`과 `refreshToken`이 정상적으로 포함되는지 확인
3. 인증이 필요한 다른 API(e.g., `GET /api/v1/users/me`)를 호출했을 때, Postman이 저장한 쿠키를 통해 인증이 성공하여 200 OK 응답을 받는지 확인

### 2. 소셜 로그인 (프론트엔드 연동)
1. 프론트엔드단에서 'Google로 로그인' 버튼을 클릭합니다. (`/oauth2/authorization/google` 링크로 이동)
2. Google 로그인 페이지에서 로그인을 완료
3. 서버가 지정된 프론트엔드의 콜백 URL로 정상적으로 리디렉션하는지 확인합니다.
4. 리디렉션된 후, 브라우저의 개발자 도구(Application > Cookies)에 `HttpOnly` 속성의 `accessToken`과 `refreshToken`이 저장되었는지 확인
5. 인증이 필요한 API가 정상적으로 호출되는지 확인
