### PR TITLE
커스텀 @LoginUserId 어노테이션 및 ArgumentResolver 적용으로 사용자 ID 중복 제거

### DIFF
--- a/src/main/java/com/sing4u/kr/common/auth/LoginUserId.java
+++ b/src/main/java/com/sing4u/kr/common/auth/LoginUserId.java
@@ -1,0 +1,10 @@
+package com.sing4u.kr.common.auth;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.PARAMETER) //적용 대상
+@Retention(RetentionPolicy.RUNTIME) // 보존 정책
+public @interface LoginUserId {}

--- a/src/main/java/com/sing4u/kr/common/auth/LoginUserIdArgumentResolver.java
+++ b/src/main/java/com/sing4u/kr/common/auth/LoginUserIdArgumentResolver.java
@@ -1,0 +1,29 @@
+package com.sing4u.kr.common.auth;
+
+import com.sing4u.kr.application.utils.SecurityContextUtils;
+import org.springframework.core.MethodParameter;
+import org.springframework.stereotype.Component;
+import org.springframework.web.bind.support.WebDataBinderFactory;
+import org.springframework.web.context.request.NativeWebRequest;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.method.support.ModelAndViewContainer;
+
+@Component
+public class LoginUserIdArgumentResolver implements HandlerMethodArgumentResolver {
+    // @LoginuserId 어노테이션이 붙어 있으면 이 Resolver를 사용하도록 설정
+    @Override
+    public boolean supportsParameter(MethodParameter parameter) {
+        return parameter.hasParameterAnnotation(LoginUserId.class)
+                && parameter.getParameterType().equals(Long.class);
+    }
+
+    @Override
+    public Object resolveArgument(
+            MethodParameter parameter,
+            ModelAndViewContainer mavContainer,
+            NativeWebRequest webRequest,
+            WebDataBinderFactory binderFactory) throws Exception {
+
+        return SecurityContextUtils.getAccountId();
+    }
+}

--- a/src/main/java/com/sing4u/kr/common/config/WebConfig.java
+++ b/src/main/java/com/sing4u/kr/common/config/WebConfig.java
@@ -1,0 +1,20 @@
+package com.sing4u.kr.common.config;
+
+import com.sing4u.kr.common.auth.LoginUserIdArgumentResolver;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+import java.util.List;
+
+@Configuration
+@RequiredArgsConstructor
+public class WebConfig implements WebMvcConfigurer {
+    private final LoginUserIdArgumentResolver loginUserIdArgumentResolver;
+
+    @Override
+    public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers){
+        resolvers.add(loginUserIdArgumentResolver);
+    }
+}

--- a/src/main/java/com/sing4u/kr/user/controller/UserController.java
+++ b/src/main/java/com/sing4u/kr/user/controller/UserController.java
@@ -1,6 +1,7 @@
 package com.sing4u.kr.user.controller;
 
 import com.sing4u.kr.application.utils.SecurityContextUtils;
+import com.sing4u.kr.common.auth.LoginUserId;
 import com.sing4u.kr.common.dto.ResponseResult;
 import com.sing4u.kr.common.enums.ResponseCode;
 import com.sing4u.kr.user.dto.request.*;
@@ -34,67 +35,57 @@ public class UserController {
 
     @Operation(summary = "내 정보 조회", description = "로그인된 사용자의 상세 정보를 조회합니다.")
     @GetMapping("/me")
-    public ResponseResult<UserProfileResponse> getUserById() {
-        Long userId = SecurityContextUtils.getAccountId();
+    public ResponseResult<UserProfileResponse> getUserById(@LoginUserId Long userId) {
         return new ResponseResult<>(ResponseCode.SUCCESS, userService.getUserById(userId));
     }
 
     @Operation(summary = "내 계정 유형 변경", description = "USER 또는 ARTIST로 계정 유형을 변경합니다.")
     @PutMapping("/me/account-type")
-    public ResponseResult<Void> updateAccountType(@RequestBody @Valid UserUpdateAccountTypeRequest request) {
-        Long userId = SecurityContextUtils.getAccountId();
+    public ResponseResult<Void> updateAccountType(@LoginUserId Long userId, @RequestBody @Valid UserUpdateAccountTypeRequest request) {
         userService.updateAccountType(userId, request);
         return new ResponseResult<>(ResponseCode.SUCCESS);
     }
 
     @Operation(summary = "내 프로필 수정", description = "닉네임, 소개, 프로필 이미지 등 프로필 정보를 수정합니다.")
     @PutMapping("/me/profile")
-    public ResponseResult<UserProfileResponse> updateProfile(@RequestBody @Valid UserUpdateProfileRequest request) {
-        Long userId = SecurityContextUtils.getAccountId();
+    public ResponseResult<UserProfileResponse> updateProfile(@LoginUserId Long userId, @RequestBody @Valid UserUpdateProfileRequest request) {
         return new ResponseResult<>(ResponseCode.SUCCESS, userService.updateProfile(userId, request));
     }
 
     @Operation(summary = "내 활동 플랫폼 조회", description = "로그인된 사용자의 활동 플랫폼(유튜브, 인스타그램 등) 목록을 조회합니다.")
     @GetMapping("/me/activity-platform")
-    public ResponseResult<UserActivityPlatformResponse> getActivityPlatform() {
-        Long userId = SecurityContextUtils.getAccountId();
+    public ResponseResult<UserActivityPlatformResponse> getActivityPlatform(@LoginUserId Long userId) {
         return new ResponseResult<>(ResponseCode.SUCCESS, userService.getActivityPlatform(userId));
     }
 
     @Operation(summary = "내 활동 플랫폼 수정", description = "로그인된 사용자의 활동 플랫폼 목록을 수정/업데이트합니다.")
     @PutMapping("/me/activity-platform")
-    public ResponseResult<UserActivityPlatformResponse> updateActivityPlatform(@RequestBody @Valid UserUpdateActivityPlatformRequest request) {
-        Long userId = SecurityContextUtils.getAccountId();
+    public ResponseResult<UserActivityPlatformResponse> updateActivityPlatform(@LoginUserId Long userId, @RequestBody @Valid UserUpdateActivityPlatformRequest request) {
         return new ResponseResult<>(ResponseCode.SUCCESS, userService.updateActivityPlatform(userId, request));
     }
 
     @Operation(summary = "이메일 변경", description = "로그인된 사용자의 이메일을 변경합니다. 현재 비밀번호 확인이 필요합니다.")
     @PutMapping("/me/email")
-    public ResponseResult<UserUpdateEmailResponse> updateEmail(@RequestBody @Valid UserUpdateEmailRequest request) {
-        Long userId = SecurityContextUtils.getAccountId();
+    public ResponseResult<UserUpdateEmailResponse> updateEmail(@LoginUserId Long userId, @RequestBody @Valid UserUpdateEmailRequest request) {
         return new ResponseResult<>(ResponseCode.SUCCESS, userService.updateEmail(userId, request));
     }
 
     @Operation(summary = "비밀번호 변경", description = "로그인된 사용자의 비밀번호를 변경합니다. 현재 비밀번호 확인이 필요합니다.")
     @PutMapping("/me/password")
     public ResponseResult<UserUpdatePasswordResponse> updatePassword(@RequestBody @Valid UserUpdatePasswordRequest request) {
-        Long userId = SecurityContextUtils.getAccountId();
         return new ResponseResult<>(ResponseCode.SUCCESS);
     }
 
     @Operation(summary = "회원 탈퇴", description = "로그인된 사용자의 계정을 삭제(soft-delete) 처리합니다.")
     @DeleteMapping("/")
-    public ResponseResult<Void> deleteUser() {
-        Long userId = SecurityContextUtils.getAccountId();
+    public ResponseResult<Void> deleteUser(@LoginUserId Long userId) {
         userService.deleteUser(userId);
         return new ResponseResult<>(ResponseCode.SUCCESS);
     }
 
     @Operation(summary = "프로필 이미지 변경", description = "사용자의 프로필 이미지를 업로드하고 변경합니다.")
     @PutMapping(value = "/me/profile-image", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
-    public ResponseResult<UserUpdateProfileImageResponse> updateProfileImage(@RequestPart MultipartFile profileImage) {
-        Long userId = SecurityContextUtils.getAccountId();
-
+    public ResponseResult<UserUpdateProfileImageResponse> updateProfileImage(@LoginUserId Long userId, @RequestPart MultipartFile profileImage) {
         return new ResponseResult<>(ResponseCode.SUCCESS, userService.updateUserProfileImage(userId, profileImage));
     }
 


### PR DESCRIPTION
---
작업 배경
기존 UserController에서 인증된 사용자 ID를 가져오는 코드(SecurityContextUtils.getAccountId())가 여러 메서드에 중복되어 가독성과 유지보수성 저하

코드 중복 해소 및 테스트 용이성을 위해 스프링의 HandlerMethodArgumentResolver 기능 활용 필요

---
작업 내용
@LoginUserId 커스텀 어노테이션 생성

LoginUserIdArgumentResolver 구현 및 스프링 빈 등록

WebMvcConfigurer를 통해 ArgumentResolver 등록

UserController에서 중복된 사용자 ID 조회 코드 제거 및 @LoginUserId Long userId 파라미터 주입으로 변경