### PR TITLE
user public id 생성

### DIFF
--- a/src/main/java/com/sing4u/kr/user/dto/response/UserCreateResponse.java
+++ b/src/main/java/com/sing4u/kr/user/dto/response/UserCreateResponse.java
@@ -14,7 +14,7 @@ import java.time.LocalDateTime;
 public class UserCreateResponse {
 
     @Schema(description = "생성된 사용자 공개 ID", example = "cd7f1081-e380-4fc7-bb7e-23cf4d7b6d44")
-    private String publicId;
+    private String userPublicId;
 
     @Schema(description = "사용자 이메일", example = "test@example.com")
     private String email;
@@ -29,7 +29,7 @@ public class UserCreateResponse {
     private LocalDateTime createdAt;
     public static UserCreateResponse from(User user) {
         return UserCreateResponse.builder()
-                .publicId(user.getPublicId())
+                .userPublicId(user.getUserPublicId())
                 .email(user.getEmail())
                 .nickname(user.getNickname())
                 .userType(user.getUserType())

--- a/src/main/java/com/sing4u/kr/user/dto/response/UserCreateResponse.java
+++ b/src/main/java/com/sing4u/kr/user/dto/response/UserCreateResponse.java
@@ -12,8 +12,9 @@ import java.time.LocalDateTime;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor(access = AccessLevel.PROTECTED)
 public class UserCreateResponse {
-    @Schema(description = "생성된 사용자 ID", example = "1")
-    private Long userId;
+
+    @Schema(description = "생성된 사용자 공개 ID", example = "cd7f1081-e380-4fc7-bb7e-23cf4d7b6d44")
+    private String publicId;
 
     @Schema(description = "사용자 이메일", example = "test@example.com")
     private String email;
@@ -28,7 +29,7 @@ public class UserCreateResponse {
     private LocalDateTime createdAt;
     public static UserCreateResponse from(User user) {
         return UserCreateResponse.builder()
-                .userId(user.getId())
+                .publicId(user.getPublicId())
                 .email(user.getEmail())
                 .nickname(user.getNickname())
                 .userType(user.getUserType())

--- a/src/main/java/com/sing4u/kr/user/dto/response/UserListResponse.java
+++ b/src/main/java/com/sing4u/kr/user/dto/response/UserListResponse.java
@@ -11,8 +11,8 @@ import java.util.List;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor(access = AccessLevel.PROTECTED)
 public class UserListResponse {
-    @Schema(description = "사용자 ID", example = "10")
-    private Long userId;
+    @Schema(description = "생성된 사용자 공개 ID", example = "cd7f1081-e380-4fc7-bb7e-23cf4d7b6d44")
+    private String publicId;
 
     @Schema(description = "닉네임", example = "검색된유저")
     private String nickname;
@@ -23,7 +23,7 @@ public class UserListResponse {
 
     public static UserListResponse from(User user) {
         return UserListResponse.builder()
-                .userId(user.getId())
+                .publicId(user.getPublicId())
                 .nickname(user.getNickname())
                 .profileImage(user.getProfileImage())
                 .isOpen(user.isOpen())

--- a/src/main/java/com/sing4u/kr/user/dto/response/UserListResponse.java
+++ b/src/main/java/com/sing4u/kr/user/dto/response/UserListResponse.java
@@ -12,7 +12,7 @@ import java.util.List;
 @AllArgsConstructor(access = AccessLevel.PROTECTED)
 public class UserListResponse {
     @Schema(description = "생성된 사용자 공개 ID", example = "cd7f1081-e380-4fc7-bb7e-23cf4d7b6d44")
-    private String publicId;
+    private String userPublicId;
 
     @Schema(description = "닉네임", example = "검색된유저")
     private String nickname;
@@ -23,7 +23,7 @@ public class UserListResponse {
 
     public static UserListResponse from(User user) {
         return UserListResponse.builder()
-                .publicId(user.getPublicId())
+                .userPublicId(user.getUserPublicId())
                 .nickname(user.getNickname())
                 .profileImage(user.getProfileImage())
                 .isOpen(user.isOpen())

--- a/src/main/java/com/sing4u/kr/user/dto/response/UserProfileResponse.java
+++ b/src/main/java/com/sing4u/kr/user/dto/response/UserProfileResponse.java
@@ -14,8 +14,8 @@ import java.util.List;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor(access = AccessLevel.PROTECTED)
 public class UserProfileResponse {
-    @Schema(description = "사용자 ID", example = "1")
-    private Long userId;
+    @Schema(description = "생성된 사용자 공개 ID", example = "cd7f1081-e380-4fc7-bb7e-23cf4d7b6d44")
+    private String publicId;
 
     @Schema(description = "닉네임", example = "노래하는강아지")
     private String nickname;
@@ -39,7 +39,7 @@ public class UserProfileResponse {
     private LocalDateTime updatedAt;
     public static UserProfileResponse from(User user) {
         return UserProfileResponse.builder()
-                .userId(user.getId())
+                .publicId(user.getPublicId())
                 .nickname(user.getNickname())
                 .email(user.getEmail())
                 .userType(user.getUserType())

--- a/src/main/java/com/sing4u/kr/user/dto/response/UserProfileResponse.java
+++ b/src/main/java/com/sing4u/kr/user/dto/response/UserProfileResponse.java
@@ -2,20 +2,19 @@ package com.sing4u.kr.user.dto.response;
 
 import com.sing4u.kr.user.entity.User;
 import com.sing4u.kr.user.entity.enums.UserType;
-import com.sing4u.kr.user.entity.UserActivityPlatform;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.*;
 
 import java.time.LocalDateTime;
-import java.util.List;
 
 @Getter
 @Builder(access = AccessLevel.PROTECTED)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor(access = AccessLevel.PROTECTED)
 public class UserProfileResponse {
+
     @Schema(description = "생성된 사용자 공개 ID", example = "cd7f1081-e380-4fc7-bb7e-23cf4d7b6d44")
-    private String publicId;
+    private String userPublicId;
 
     @Schema(description = "닉네임", example = "노래하는강아지")
     private String nickname;
@@ -39,7 +38,7 @@ public class UserProfileResponse {
     private LocalDateTime updatedAt;
     public static UserProfileResponse from(User user) {
         return UserProfileResponse.builder()
-                .publicId(user.getPublicId())
+                .userPublicId(user.getUserPublicId())
                 .nickname(user.getNickname())
                 .email(user.getEmail())
                 .userType(user.getUserType())

--- a/src/main/java/com/sing4u/kr/user/entity/User.java
+++ b/src/main/java/com/sing4u/kr/user/entity/User.java
@@ -30,7 +30,7 @@ public class User {
     private Long id;
 
     @Column(nullable = false, unique = true, updatable = false)
-    private String publicId;
+    private String userPublicId;
 
     @Column(length = 20, nullable = false)
     private String nickname;
@@ -152,8 +152,8 @@ public class User {
 
     @PrePersist
     public void generatePublicId() {
-        if (this.publicId == null) {
-            this.publicId = UUID.randomUUID().toString();
+        if (this.userPublicId == null) {
+            this.userPublicId = UUID.randomUUID().toString();
         }
     }
 }

--- a/src/main/java/com/sing4u/kr/user/entity/User.java
+++ b/src/main/java/com/sing4u/kr/user/entity/User.java
@@ -13,6 +13,7 @@ import org.hibernate.annotations.DynamicUpdate;
 import org.hibernate.annotations.UpdateTimestamp;
 
 import java.time.LocalDateTime;
+import java.util.UUID;
 
 @Entity
 @Getter
@@ -27,6 +28,9 @@ public class User {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
+
+    @Column(nullable = false, unique = true, updatable = false)
+    private String publicId;
 
     @Column(length = 20, nullable = false)
     private String nickname;
@@ -144,5 +148,12 @@ public class User {
                 .userType(UserType.FAN)
                 .socialType(socialType)
                 .build();
+    }
+
+    @PrePersist
+    public void generatePublicId() {
+        if (this.publicId == null) {
+            this.publicId = UUID.randomUUID().toString();
+        }
     }
 }

--- a/src/main/java/com/sing4u/kr/user/repository/UserRepository.java
+++ b/src/main/java/com/sing4u/kr/user/repository/UserRepository.java
@@ -12,5 +12,6 @@ public interface UserRepository extends JpaRepository<User, Long>, UserCustomRep
     Optional<User> findByEmailAndDeletedAtIsNull(String email);
     Optional<User> findByIdAndUserType(Long id, UserType userType);
     Optional<User> findByIdAndUserTypeAndDeletedAtIsNull(Long id, UserType userType);
+    Optional<User> findByPublicIdAndDeletedAtIsNull(String publicId);
 }
 


### PR DESCRIPTION
## 변경 내용

- `User` 엔티티에 `publicId`(UUID) 필드 추가
  - 회원가입 시 UUID 자동 생성되도록 설정
- 외부에 노출되는 DTO에서 기존의 내부 PK(`userId`) 대신 `publicId` 반환하도록 변경
  - `UserCreateResponse`
  - `UserListResponse`
  - `UserProfileResponse` 등
- 내부 로직은 여전히 `userId(Long)`을 기준으로 작동
- `UserRepository`에 `findByPublicIdAndDeletedAtIsNull` 추가

## 변경 목적

- 보안 강화: 외부에 DB의 PK(Long) 노출 방지
- 사용자 식별을 위한 UUID 기반 공개 ID 도입