### PR TITLE
Refactor public id usage

### DIFF
--- a/src/main/java/com/sing4u/kr/session/controller/SessionController.java
+++ b/src/main/java/com/sing4u/kr/session/controller/SessionController.java
@@ -5,6 +5,8 @@ import com.sing4u.kr.common.enums.ResponseCode;
 import com.sing4u.kr.session.dto.response.CurrentSessionResponseDto;
 import com.sing4u.kr.session.dto.response.SessionResponseDto;
 import com.sing4u.kr.session.service.SessionService;
+import com.sing4u.kr.user.entity.User;
+import com.sing4u.kr.user.service.UserService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import lombok.RequiredArgsConstructor;
@@ -16,32 +18,36 @@ import org.springframework.web.bind.annotation.*;
 public class SessionController {
 
     private final SessionService sessionService;
+    private final UserService userService;
 
     @Operation(summary = "세션 시작", description = "아티스트가 신청곡 받기를 시작합니다.")
-    @PostMapping("/{artistId}/sessions")
+    @PostMapping("/{artistPublicId}/sessions")
     public ResponseResult<SessionResponseDto> startSession(
-            @Parameter(description = "세션을 시작할 아티스트의 ID", example = "1")
-            @PathVariable Long artistId) {
+            @Parameter(description = "세션을 시작할 아티스트의 공개 ID", example = "user_public_id_3")
+            @PathVariable String artistPublicId) {
+        Long artistId = userService.getUserIdByPublicId(artistPublicId);
         SessionResponseDto sessionResponse = sessionService.createSession(artistId);
         return new ResponseResult<>(ResponseCode.SUCCESS, sessionResponse);
     }
 
     @Operation(summary = "세션 종료", description = "신청곡 받기를 종료 처리합니다.")
-    @PatchMapping("/{artistId}/sessions/{sessionId}/close")
+    @PatchMapping("/{artistPublicId}/sessions/{sessionId}/close")
     public ResponseResult<SessionResponseDto> closeSession(
-            @Parameter(description = "세션을 종료할 아티스트의 ID", example = "1")
-            @PathVariable Long artistId,
-            @Parameter(description = "종료할 세션의 ID", example = "101")
+            @Parameter(description = "세션을 종료할 아티스트의 공개 ID", example = "user_public_id_1")
+            @PathVariable String artistPublicId,
+            @Parameter(description = "종료할 세션의 ID", example = "1")
             @PathVariable Long sessionId) {
+        Long artistId = userService.getUserIdByPublicId(artistPublicId);
         SessionResponseDto sessionResponse = sessionService.closeSession(artistId, sessionId);
         return new ResponseResult<>(ResponseCode.SUCCESS, sessionResponse);
     }
 
     @Operation(summary = "현재 오픈된 세션 조회", description = "아티스트의 현재 진행 중인 세션 정보를 조회합니다.")
-    @GetMapping("/{artistId}/sessions")
+    @GetMapping("/{artistPublicId}/sessions")
     public ResponseResult<CurrentSessionResponseDto> getArtistCurrentOpenSession(
-            @Parameter(description = "세션 정보를 조회할 아티스트의 ID", example = "1")
-            @PathVariable Long artistId) {
+            @Parameter(description = "세션 정보를 조회할 아티스트의 공개 ID", example = "user_public_id_1")
+            @PathVariable String artistPublicId) {
+        Long artistId = userService.getUserIdByPublicId(artistPublicId);
         CurrentSessionResponseDto currentSession = sessionService.getArtistOpenSession(artistId);
 
         if (currentSession == null) {

--- a/src/main/java/com/sing4u/kr/session/dto/response/CurrentSessionResponseDto.java
+++ b/src/main/java/com/sing4u/kr/session/dto/response/CurrentSessionResponseDto.java
@@ -14,8 +14,8 @@ public class CurrentSessionResponseDto {
     @Schema(description = "세션 ID", example = "101")
     private Long sessionId;
 
-    @Schema(description = "세션을 진행 중인 아티스트 ID", example = "1")
-    private Long artistId;
+    @Schema(description = "세션을 진행 중인 아티스트 ID", example = "user_public_id_1")
+    private String artistId;
 
     @Schema(description = "세션 상태 (항상 OPEN)", example = "OPEN", implementation = SessionStatus.class)
     private SessionStatus status;
@@ -25,7 +25,7 @@ public class CurrentSessionResponseDto {
     public static CurrentSessionResponseDto from(Session session) {
         return CurrentSessionResponseDto.builder()
                 .sessionId(session.getId())
-                .artistId(session.getArtist().getId())
+                .artistId(session.getArtist().getUserPublicId())
                 .status(session.getStatus())
                 .startedAt(session.getStartedAt())
                 .build();

--- a/src/main/java/com/sing4u/kr/session/dto/response/SessionResponseDto.java
+++ b/src/main/java/com/sing4u/kr/session/dto/response/SessionResponseDto.java
@@ -13,11 +13,11 @@ import java.time.LocalDateTime;
 @Builder
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public class SessionResponseDto {
-    @Schema(description = "세션 ID", example = "101")
+    @Schema(description = "세션 ID", example = "1")
     private Long sessionId;
 
-    @Schema(description = "세션의 아티스트 ID", example = "1")
-    private Long artistId;
+    @Schema(description = "세션의 아티스트 ID", example = "public_user_id_1")
+    private String artistId;
 
     @Schema(description = "세션 상태", example = "OPEN",implementation = SessionStatus.class)
     private SessionStatus status;
@@ -31,7 +31,7 @@ public class SessionResponseDto {
     public static SessionResponseDto from(Session session) {
         return SessionResponseDto.builder()
                 .sessionId(session.getId())
-                .artistId(session.getArtist().getId())
+                .artistId(session.getArtist().getUserPublicId())
                 .status(session.getStatus())
                 .startedAt(session.getStartedAt())
                 .closedAt(session.getClosedAt())

--- a/src/main/java/com/sing4u/kr/session/dto/response/SessionResponseDto.java
+++ b/src/main/java/com/sing4u/kr/session/dto/response/SessionResponseDto.java
@@ -16,7 +16,7 @@ public class SessionResponseDto {
     @Schema(description = "세션 ID", example = "1")
     private Long sessionId;
 
-    @Schema(description = "세션의 아티스트 ID", example = "public_user_id_1")
+    @Schema(description = "세션의 아티스트 ID", example = "user_public_id_1")
     private String artistId;
 
     @Schema(description = "세션 상태", example = "OPEN",implementation = SessionStatus.class)

--- a/src/main/java/com/sing4u/kr/songRequest/controller/SongRequestController.java
+++ b/src/main/java/com/sing4u/kr/songRequest/controller/SongRequestController.java
@@ -33,7 +33,7 @@ public class SongRequestController {
     @Operation(summary = "아티스트 곡 요청 목록 조회", description = "특정 아티스트에게 요청된 커스텀 곡 요청 목록을 조회")
     @GetMapping("/artists/{artistPublicId}")
     public ResponseResult<List<SessionSongsDto>> getArtistSongRequests(
-            @Parameter(description = "곡 요청 목록을 조회할 아티스트의 ID", example = "1")
+            @Parameter(description = "곡 요청 목록을 조회할 아티스트의 공개 ID", example = "user_public_id_1")
             @PathVariable String artistPublicId) {
         Long artistId = userService.getUserIdByPublicId(artistPublicId);
         List<SessionSongsDto> songRequests = songRequestService.getSongRequestsByArtist(artistId);

--- a/src/main/java/com/sing4u/kr/songRequest/controller/SongRequestController.java
+++ b/src/main/java/com/sing4u/kr/songRequest/controller/SongRequestController.java
@@ -6,6 +6,7 @@ import com.sing4u.kr.songRequest.dto.request.SongRequestCreateDto;
 import com.sing4u.kr.songRequest.dto.SongRequestResponseDto;
 import com.sing4u.kr.songRequest.service.SongRequestService;
 import com.sing4u.kr.session.dto.SessionSongsDto;
+import com.sing4u.kr.user.service.UserService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import jakarta.validation.Valid;
@@ -20,6 +21,7 @@ import java.util.List;
 public class SongRequestController {
 
     private final SongRequestService songRequestService;
+    private final UserService userService;
 
     @Operation(summary = "곡 요청 제출", description = "팬이 아티스트에게 곡 요청을 제출합니다.")
     @PostMapping
@@ -29,10 +31,11 @@ public class SongRequestController {
     }
 
     @Operation(summary = "아티스트 곡 요청 목록 조회", description = "특정 아티스트에게 요청된 커스텀 곡 요청 목록을 조회")
-    @GetMapping("/artists/{artistId}")
+    @GetMapping("/artists/{artistPublicId}")
     public ResponseResult<List<SessionSongsDto>> getArtistSongRequests(
             @Parameter(description = "곡 요청 목록을 조회할 아티스트의 ID", example = "1")
-            @PathVariable Long artistId) {
+            @PathVariable String artistPublicId) {
+        Long artistId = userService.getUserIdByPublicId(artistPublicId);
         List<SessionSongsDto> songRequests = songRequestService.getSongRequestsByArtist(artistId);
         return new ResponseResult<>(ResponseCode.SUCCESS, songRequests);
     }

--- a/src/main/java/com/sing4u/kr/songRequest/dto/request/SongRequestCreateDto.java
+++ b/src/main/java/com/sing4u/kr/songRequest/dto/request/SongRequestCreateDto.java
@@ -8,11 +8,11 @@ import lombok.Data;
 @Data
 public class SongRequestCreateDto {
     @NotNull(message = "아티스트 ID는 필수입니다.")
-    @Schema(description = "곡을 요청할 아티스트의 ID", example = "1")
-    private Long artistId;
+    @Schema(description = "곡을 요청할 아티스트의 공개 ID", example = "user_public_id_1")
+    private String artistPublicId;
 
     @NotNull(message = "세션 ID는 필수입니다.")
-    @Schema(description = "요청이 속하게 될 세션의 ID", example = "101")
+    @Schema(description = "요청이 속하게 될 세션의 ID", example = "1")
     private Long sessionId;
 
     @Size(max = 50, message = "이메일은 최대 50자까지 가능합니다.")

--- a/src/main/java/com/sing4u/kr/songRequest/service/SongRequestService.java
+++ b/src/main/java/com/sing4u/kr/songRequest/service/SongRequestService.java
@@ -18,6 +18,7 @@ import com.sing4u.kr.session.dto.SessionSongsDto;
 import com.sing4u.kr.user.repository.UserRepository;
 import com.sing4u.kr.user.entity.enums.UserType;
 
+import com.sing4u.kr.user.service.UserService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -39,6 +40,8 @@ public class SongRequestService {
     private final MusicPlatformFactory musicPlatformFactory;
 
     private record SongInfo(String title, String artistName, String platformTrackId, String platformName){}
+
+    private final UserService userService;
 
     private SongInfo determineSongInfo(SongRequestCreateDto createDto) {
         String title = createDto.getSongTitle();
@@ -94,7 +97,8 @@ public class SongRequestService {
         Session session = sessionRepository.findById(createDto.getSessionId())
                 .orElseThrow(() -> new ApiException(ExceptionCode.NOT_FOUND, "세션을 찾을 수 없습니다. ID: " + createDto.getSessionId()));
 
-        validateSession(session, createDto.getArtistId());
+        Long artistId = userService.getUserIdByPublicId(createDto.getArtistPublicId());
+        validateSession(session, artistId);
 
         // DB 작업: 엔티티 생성 및 저장
         SongRequest songRequest = SongRequest.builder()

--- a/src/main/java/com/sing4u/kr/user/controller/UserController.java
+++ b/src/main/java/com/sing4u/kr/user/controller/UserController.java
@@ -60,7 +60,8 @@ public class UserController {
 
     @Operation(summary = "비밀번호 변경", description = "로그인된 사용자의 비밀번호를 변경합니다. 현재 비밀번호 확인이 필요합니다.")
     @PutMapping("/me/password")
-    public ResponseResult<UserUpdatePasswordResponse> updatePassword(@RequestBody @Valid UserUpdatePasswordRequest request) {
+    public ResponseResult<UserUpdatePasswordResponse> updatePassword(@LoginUserId Long userId, @RequestBody @Valid UserUpdatePasswordRequest request) {
+        userService.updatePassword(userId, request);
         return new ResponseResult<>(ResponseCode.SUCCESS);
     }
 

--- a/src/main/java/com/sing4u/kr/user/dto/request/UserUpdateActivityPlatformRequest.java
+++ b/src/main/java/com/sing4u/kr/user/dto/request/UserUpdateActivityPlatformRequest.java
@@ -15,7 +15,8 @@ import java.util.List;
 @AllArgsConstructor(access = AccessLevel.PROTECTED)
 public class UserUpdateActivityPlatformRequest {
 
-    @Schema(description = "수정할 활동 플랫폼 목록", implementation = ActivityPlatformRequest.class)
+    @Schema(description = "수정할 활동 플랫폼 목록", implementation = ActivityPlatformRequest.class,
+            example = "[{\"platformType\": \"YOUTUBE\", \"platformUrl\": \"https://www.youtube.com/channel/UC-abcdefg\"}]")
     @NotEmpty(message = "활동 플랫폼 리스트를 입력해주세요.")
     @Size(min = 1, message = "최소 1개 이상의 활동 플랫폼이 필요합니다.")
     private List<ActivityPlatformRequest> activityPlatforms;

--- a/src/main/java/com/sing4u/kr/user/dto/request/UserUpdatePasswordRequest.java
+++ b/src/main/java/com/sing4u/kr/user/dto/request/UserUpdatePasswordRequest.java
@@ -13,9 +13,9 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor(access = AccessLevel.PROTECTED)
 public class UserUpdatePasswordRequest {
 
-    @Schema(description = "현재 비밀번호", example = "password1234")
+    @Schema(description = "현재 비밀번호", example = "user_1")
     @NotBlank(message = "비밀번호는 필수입니다.")
-    @Size(min = 8, message = "비밀번호는 최소 8자 이상이어야 합니다.")
+    //@Size(min = 8, message = "비밀번호는 최소 8자 이상이어야 합니다.")
     private String password;
 
     @Schema(description = "새로운 비밀번호", example = "new_password5678")

--- a/src/main/java/com/sing4u/kr/user/dto/request/UserUpdatePasswordRequest.java
+++ b/src/main/java/com/sing4u/kr/user/dto/request/UserUpdatePasswordRequest.java
@@ -13,7 +13,7 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor(access = AccessLevel.PROTECTED)
 public class UserUpdatePasswordRequest {
 
-    @Schema(description = "현재 비밀번호", example = "user_1")
+    @Schema(description = "현재 비밀번호", example = "password1234")
     @NotBlank(message = "비밀번호는 필수입니다.")
     //@Size(min = 8, message = "비밀번호는 최소 8자 이상이어야 합니다.")
     private String password;

--- a/src/main/java/com/sing4u/kr/user/service/UserService.java
+++ b/src/main/java/com/sing4u/kr/user/service/UserService.java
@@ -134,7 +134,7 @@ public class UserService {
         }
         user.updatePassword(passwordEncoder.encode(request.getNewPassword()));
         userRepository.save(user);
-        // return UserUpdatePasswordResponse.from(user);
+        //return UserUpdatePasswordResponse.from(user);
     }
 
     @Transactional
@@ -161,5 +161,13 @@ public class UserService {
         this.userRepository.save(user);
 
         return UserUpdateProfileImageResponse.of(user.getProfileImage());
+    }
+
+    @Transactional(readOnly = true)
+    public Long getUserIdByPublicId(String publicId) {
+        User user = userRepository.findByUserPublicIdAndDeletedAtIsNull(publicId)
+                .orElseThrow(() -> new Exception400("사용자를 찾을 수 없습니다.", ResponseCode.ERROR_NO_DATA));
+
+        return user.getId();
     }
 }


### PR DESCRIPTION
## 🔧 주요 변경 사항
- `UserService`에  `getUserIdByPublicId()` 메소드 추가
- 기존에 `@PathVariable Long id`를 사용하던 컨트롤러 일부를 `publicId` 기반으로 수정
  - `SessionController`
  - `SongRequestController`
- `SongRequestService`, `SessionService` 등 일부 서비스 로직에서 User 조회를 publicId 기반으로 변경
→ 전에 추가했던 `UserRepository`의 `findByUserPublicIdAndDeletedAtIsNull(String publicId)` 메소드를 사용

---

## 📌 변경 목적
- 저번 리팩토링 때 `User`쪽만 수정해서 `SongRequest`와 `Session`쪽에도 사용할 수 있게 변경

---

## ✅ 기대 효과
- 보안상 더 안전한 API 설계 구조로 전환
- URL 공유 및 외부 식별자 노출 시 안정적인 방식 적용

---

## 🛠 기타 수정 사항

- 비밀번호 변경 API (`PUT /avi/v1/users/me/password`)에서 실제 비밀번호 변경 로직이 실행되지 않던 문제 수정
  - 기존에는 컨트롤러에서 `UserService.updatePassword()` 호출이 누락되어 있었음
  - 해당 호출 추가 및 요청자 식별을 위한 `@LoginUserId` 적용
  - 응답 타입은 보안을 고려하여 `ResponseResult<Void>`로 유지
