### PR TITLE
프로필 이미지 삭제

### DIFF
--- a/src/main/java/com/sing4u/kr/common/exception/ApiException.java
+++ b/src/main/java/com/sing4u/kr/common/exception/ApiException.java
@@ -39,4 +39,10 @@ public class ApiException extends RuntimeException {
         this.code = exceptionCode.getCode();
         this.message = customMessage != null ? customMessage : exceptionCode.getDefaultMessage();
     }
+
+    public ApiException(ExceptionCode exceptionCode) {
+        super(exceptionCode.getDefaultMessage());
+        this.code = exceptionCode.getCode();
+        this.message = exceptionCode.getDefaultMessage();
+    }
 }

--- a/src/main/java/com/sing4u/kr/common/exception/ExceptionCode.java
+++ b/src/main/java/com/sing4u/kr/common/exception/ExceptionCode.java
@@ -17,7 +17,8 @@ public enum ExceptionCode {
     
     // 도메인별 에러
     CUSTOMER_NOT_FOUND(HttpStatus.NOT_FOUND, "CUSTOMER_NOT_FOUND", "Customer not found."),
-    ORDER_CANNOT_BE_CANCELED(HttpStatus.CONFLICT, "ORDER_CANNOT_BE_CANCELED", "Order cannot be canceled.");
+    ORDER_CANNOT_BE_CANCELED(HttpStatus.CONFLICT, "ORDER_CANNOT_BE_CANCELED", "Order cannot be canceled."),
+    S3_FILE_DELETE_FAIL(HttpStatus.INTERNAL_SERVER_ERROR, "S3_FILE_DELETE_FAIL", "S3 파일 삭제에 실패했습니다.");
 
     private final HttpStatus status;
     private final String code;

--- a/src/main/java/com/sing4u/kr/file/service/S3Service.java
+++ b/src/main/java/com/sing4u/kr/file/service/S3Service.java
@@ -1,5 +1,7 @@
 package com.sing4u.kr.file.service;
 
+import com.sing4u.kr.common.exception.ApiException;
+import com.sing4u.kr.common.exception.ExceptionCode;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
@@ -11,6 +13,7 @@ import software.amazon.awssdk.services.s3.model.PutObjectRequest;
 
 
 import java.nio.file.Path;
+import java.util.regex.Pattern;
 
 import com.sing4u.kr.file.utils.FileUtils;
 
@@ -46,12 +49,40 @@ public class S3Service {
     }
 
     private String generateUploadPath(String path, MultipartFile file) {
-        return Path.of(this.activeProfile,
-                path,
-                FileUtils.generateFileName(file)).toString();
+        return String.join("/", this.activeProfile, path, FileUtils.generateFileName(file));
     }
 
     private String getFullPath(String path) {
         return this.fileUrl + path;
+    }
+
+    public void deleteFile(String fullUrl) {
+        if (fullUrl == null || fullUrl.isBlank()) {
+            throw new IllegalArgumentException("Provided S3 URL is null or blank.");
+        }
+
+        if (!fullUrl.startsWith(fileUrl)) {
+            throw new IllegalArgumentException("URL does not match fileUrl: " + fullUrl);
+        }
+
+        String key = fullUrl.replaceFirst("^" + Pattern.quote(fileUrl), "");
+
+        try {
+            boolean exists = s3Client.headObject(builder -> builder
+                    .bucket(bucketName)
+                    .key(key)
+                    .build()).sdkHttpResponse().isSuccessful();
+
+            if (!exists) {
+                throw new ApiException(ExceptionCode.S3_FILE_DELETE_FAIL, "S3 object does not exist: " + key);
+            }
+
+            s3Client.deleteObject(builder -> builder
+                    .bucket(bucketName)
+                    .key(key)
+                    .build());
+        } catch (Exception e) {
+            throw new ApiException(ExceptionCode.S3_FILE_DELETE_FAIL);
+        }
     }
 }

--- a/src/main/java/com/sing4u/kr/user/controller/UserController.java
+++ b/src/main/java/com/sing4u/kr/user/controller/UserController.java
@@ -78,4 +78,11 @@ public class UserController {
         return new ResponseResult<>(ResponseCode.SUCCESS, userService.updateUserProfileImage(userId, profileImage));
     }
 
+    @Operation(summary = "프로필 이미지 삭제", description = "사용자의 프로필 이미지를 삭제합니다.")
+    @PatchMapping("/me/profile-image/delete")
+    public ResponseResult<Void> deleteProfileImage(@LoginUserId Long userId) {
+        userService.deleteUserProfileImage(userId);
+        return new ResponseResult<>(ResponseCode.SUCCESS);
+    }
+
 }

--- a/src/main/java/com/sing4u/kr/user/service/UserService.java
+++ b/src/main/java/com/sing4u/kr/user/service/UserService.java
@@ -182,6 +182,6 @@ public class UserService {
         }
 
         user.setProfileImage(null);
-        userRepository.save(user);
+        //userRepository.save(user);
     }
 }

--- a/src/main/java/com/sing4u/kr/user/service/UserService.java
+++ b/src/main/java/com/sing4u/kr/user/service/UserService.java
@@ -1,5 +1,6 @@
 package com.sing4u.kr.user.service;
 
+import com.sing4u.kr.common.dto.ResponseResult;
 import com.sing4u.kr.file.service.S3Service;
 import com.sing4u.kr.common.enums.ResponseCode;
 import com.sing4u.kr.common.exception.Exception400;
@@ -169,5 +170,18 @@ public class UserService {
                 .orElseThrow(() -> new Exception400("사용자를 찾을 수 없습니다.", ResponseCode.ERROR_NO_DATA));
 
         return user.getId();
+    }
+
+    @Transactional
+    public void deleteUserProfileImage(Long id) {
+        User user = this.getEntityOrThrow(id);
+
+        String imageUrl = user.getProfileImage();
+        if (imageUrl != null) {
+            s3Service.deleteFile(imageUrl); // 전체 URL 넘겨도 내부에서 key 추출
+        }
+
+        user.setProfileImage(null);
+        userRepository.save(user);
     }
 }

--- a/src/main/java/com/sing4u/kr/user/utils/UserFileUtils.java
+++ b/src/main/java/com/sing4u/kr/user/utils/UserFileUtils.java
@@ -8,4 +8,11 @@ public class UserFileUtils {
     public String getProfileImageKey(Long userId) {
         return String.format("user/%d/profile", userId);
     }
+
+    public static String extractS3KeyFromUrl(String fileUrl, String fullUrl) {
+        if (fullUrl != null && fullUrl.startsWith(fileUrl)) {
+            return fullUrl.replace(fileUrl, "");
+        }
+        return null;
+    }
 }


### PR DESCRIPTION
## 변경 내용
- PATCH /api/v1/users/me/profile-image/delete API 추가
- S3에서 프로필 이미지 삭제 처리 (`deleteFile` 메소드)
- DB에서 사용자 profileImage 필드 null 처리

## 기타
- 기존에 저장된 fullUrl에서 key를 추출하여 S3 삭제
- 파일 존재하지 않을 경우 예외 처리 (ApiException 활용)
- `ExceptionCode.S3_FILE_DELETE_FAIL` 추가

## 추가 수정 사항
- `generateUploadPath` OS에 따라 경로 구분자가 달라지는 문제 해결 위해 수정
  - 기존: Path.of(...) 사용 → Windows에서 역슬래시(`\`)로 인해 S3 key가 깨짐
  - 수정: String.join("/", ...) 사용하여 모든 OS에서 S3 key를 슬래시(`/`) 기준으로 통일