### PR TITLE
feat: 로그아웃 API 추가

### DIFF
--- a/src/main/java/com/sing4u/kr/auth/controller/AuthController.java
+++ b/src/main/java/com/sing4u/kr/auth/controller/AuthController.java
@@ -7,8 +7,10 @@ import com.sing4u.kr.auth.dto.response.TokenDto;
 import com.sing4u.kr.auth.dto.response.TokenResponse;
 import com.sing4u.kr.auth.service.AuthService;
 import com.sing4u.kr.auth.utils.CookieUtils;
+import com.sing4u.kr.common.auth.LoginUserId;
 import com.sing4u.kr.common.dto.ResponseResult;
 import com.sing4u.kr.common.enums.ResponseCode;
+import io.swagger.v3.oas.annotations.Operation;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
@@ -40,6 +42,19 @@ public class AuthController {
         TokenDto dto = authService.refresh(refreshToken);
         CookieUtils.setRefreshTokenCookie(response, dto.getRefreshToken());
         return new ResponseResult<>(ResponseCode.SUCCESS, TokenResponse.of(dto.getAccessToken(), dto.getRefreshToken()));
+    }
+
+    @Operation(summary = "로그아웃", description = "사용자의 AccessToken / RefreshToken 쿠키를 삭제합니다.")
+    @PostMapping("/logout")
+    public ResponseResult<Void> logout(@LoginUserId Long userId, HttpServletResponse response) {
+        // RefreshToken db에서 삭제
+        authService.logout(userId);
+
+        // 쿠키 삭제: accessToken / refreshToken
+        CookieUtils.deleteAccessTokenCookie(response);
+        CookieUtils.deleteRefreshTokenCookie(response);
+
+        return new ResponseResult<>(ResponseCode.SUCCESS);
     }
 
 }

--- a/src/main/java/com/sing4u/kr/auth/repository/RefreshTokenRepository.java
+++ b/src/main/java/com/sing4u/kr/auth/repository/RefreshTokenRepository.java
@@ -13,4 +13,5 @@ public interface RefreshTokenRepository extends JpaRepository<RefreshToken, Long
     // 토큰 값으로 RefreshToken을 삭제하는 메서드
     void deleteByToken(String token);
 
+    void deleteByUserId(Long userId);
 }

--- a/src/main/java/com/sing4u/kr/auth/service/AuthService.java
+++ b/src/main/java/com/sing4u/kr/auth/service/AuthService.java
@@ -98,4 +98,9 @@ public class AuthService {
 
         return TokenDto.of(newAccessToken, newRefreshToken);
     }
+
+    @Transactional
+    public void logout(Long userId) {
+        refreshTokenRepository.deleteByUserId(userId);
+    }
 }

--- a/src/main/java/com/sing4u/kr/auth/utils/CookieUtils.java
+++ b/src/main/java/com/sing4u/kr/auth/utils/CookieUtils.java
@@ -60,4 +60,28 @@ public class CookieUtils {
 
         response.addHeader(HttpHeaders.SET_COOKIE, cookie.toString());
     }
+
+    public static void deleteRefreshTokenCookie(HttpServletResponse response) {
+        ResponseCookie cookie = ResponseCookie.from(cookieProperties.getRefreshName(), "")
+                .httpOnly(cookieProperties.isRefreshHttpOnly())
+                .secure(cookieProperties.isRefreshSecure())
+                .sameSite(cookieProperties.getRefreshSameSite())
+                .path(cookieProperties.getRefreshPath())
+                .maxAge(0) // 즉시 만료
+                .build();
+
+        response.addHeader(HttpHeaders.SET_COOKIE, cookie.toString());
+    }
+
+    public static void deleteAccessTokenCookie(HttpServletResponse response) {
+        ResponseCookie cookie = ResponseCookie.from(cookieProperties.getAccessName(), "")
+                .httpOnly(cookieProperties.isAccessHttpOnly())
+                .secure(cookieProperties.isAccessSecure())
+                .sameSite(cookieProperties.getAccessSameSite())
+                .path(cookieProperties.getAccessPath())
+                .maxAge(0) // 즉시 만료
+                .build();
+
+        response.addHeader(HttpHeaders.SET_COOKIE, cookie.toString());
+    }
 }


### PR DESCRIPTION
### 📌 개요
로그인된 사용자의 refresh token 을 DB와 클라이언트 쿠키에서 삭제하는 로그아웃 API 추가

### ✅ 변경 사항

- AuthController에 로그아웃 엔드포인트 /api/v1/auth/logout 추가

- AuthService에 logout 로직 구현

  - DB에서 해당 유저의 refresh token 삭제

  - 클라이언트 쿠키(access/refresh) 삭제

- CookieUtils에 access/refresh token 삭제 메서드 추가
