### PR TITLE
feat: 세션별 신청곡 중복 그룹 처리 및 count 필드 추가

### DIFF
--- a/src/main/java/com/sing4u/kr/songRequest/dto/response/SongDetailDto.java
+++ b/src/main/java/com/sing4u/kr/songRequest/dto/response/SongDetailDto.java
@@ -18,17 +18,23 @@ public class SongDetailDto {
     private String spotifyTrackId;
     private LocalDateTime requestedAt;
 
-    public static SongDetailDto from(SongRequest songRequest) {
+    private Long count;
+
+//
+
+    public static SongDetailDto from(SongRequest songRequest, Long count) {
         if (songRequest == null) {
             return null;
         }
+
         return SongDetailDto.builder()
                 .songRequestId(songRequest.getId())
                 .songTitle(songRequest.getSongTitle())
                 .singer(songRequest.getSongArtistName())
-                .email(songRequest.getFanEmail())
+                .email(songRequest.getFanEmail()) // 그룹 기준에서는 신청자 정보는 의미 없음
                 .spotifyTrackId(songRequest.getPlatformTrackId())
                 .requestedAt(songRequest.getRequestedAt())
+                .count(count)
                 .build();
     }
 }

--- a/src/main/java/com/sing4u/kr/songRequest/service/SongRequestService.java
+++ b/src/main/java/com/sing4u/kr/songRequest/service/SongRequestService.java
@@ -26,6 +26,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.util.Comparator;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
@@ -134,11 +135,22 @@ public class SongRequestService {
 
         return sessions.stream()
                 .map(session -> {
-                    List<SongDetailDto> songDetails = session.getSongRequests().stream()
-                            .sorted(Comparator.comparing(SongRequest::getRequestedAt))
-                            .map(SongDetailDto::from)
-                            .collect(Collectors.toList());
+                    // step 1 곡 제목 :: 아티스트이름 으로 그룹핑
+                    Map<String, List<SongRequest>> grouped = session.getSongRequests().stream()
+                            .collect(Collectors.groupingBy(
+                                    req -> req.getSongTitle() + ":: " + req.getSongArtistName()
+                            ));
 
+                    // step 2 그룹별로 생성
+                    List<SongDetailDto> songDetails = grouped.entrySet().stream()
+                            .map(entry -> {
+                                List<SongRequest> requests = entry.getValue();
+                                SongRequest latest = requests.get(requests.size() - 1);
+
+                                return SongDetailDto.from(latest, (long) requests.size());
+                            })
+                            .sorted(Comparator.comparing(SongDetailDto::getRequestedAt))
+                            .collect(Collectors.toList());
                     return SessionSongsDto.from(session, songDetails);
                 })
                 .collect(Collectors.toList());

--- a/src/main/java/com/sing4u/kr/songRequest/service/SongRequestService.java
+++ b/src/main/java/com/sing4u/kr/songRequest/service/SongRequestService.java
@@ -138,7 +138,7 @@ public class SongRequestService {
                     // step 1 곡 제목 :: 아티스트이름 으로 그룹핑
                     Map<String, List<SongRequest>> grouped = session.getSongRequests().stream()
                             .collect(Collectors.groupingBy(
-                                    req -> req.getSongTitle() + ":: " + req.getSongArtistName()
+                                    req -> req.getSongTitle() + "::" + req.getSongArtistName()
                             ));
 
                     // step 2 그룹별로 생성

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -72,8 +72,8 @@ endpoints:
     - /api/v1/auth/refresh
 
 sing4u:
-  #server-url: http://localhost:8080
-  server-url: https://dev-api.sing4u.kr
+  server-url: http://localhost:8080
+#  server-url: https://dev-api.sing4u.kr
   file-url: https://image.sing4u.kr/
   oauth-redirect-url: http://localhost:3000/auth/callback
 


### PR DESCRIPTION
## 🔍 작업 개요
- 세션별 신청곡 목록 조회 시, 동일한 곡(제목 + 아티스트)을 하나로 그룹핑
- 각 곡에 대해 신청 횟수(`count`) 포함한 응답 구조로 변경

---

## ✅ 주요 변경 사항
- `SongDetailDto`에 `count` 필드 추가 및 `from(SongRequest, Long)` 팩토리 메서드 생성
- `getSongRequestsByArtist()` 내부 로직:
  - 세션별 `SongRequest` 리스트를 `(title + artist)` 기준으로 그룹핑
  - 그룹 내 최신 요청 1건 + 요청 수(`count`) 기준으로 `SongDetailDto` 생성