### PR TITLE
HOME-API 응답 JSON 필드명 변경

### DIFF
--- a/src/main/java/com/sing4u/kr/common/response/PagingResponse.java
+++ b/src/main/java/com/sing4u/kr/common/response/PagingResponse.java
@@ -10,7 +10,7 @@ import java.util.List;
 @Getter
 @Builder
 public class PagingResponse<T> {
-    private final List<T> data;
+    private final List<T> artistItems;
     private final int page;
     private final int size;
     private final Long totalElements; // Page일 경우에만 값 제공
@@ -19,7 +19,7 @@ public class PagingResponse<T> {
 
     public static <T> PagingResponse<T> of(Page<T> pageData) {
         return PagingResponse.<T>builder()
-                .data(pageData.getContent())
+                .artistItems(pageData.getContent())
                 .page(pageData.getNumber())
                 .size(pageData.getSize())
                 .totalElements(pageData.getTotalElements())
@@ -30,7 +30,7 @@ public class PagingResponse<T> {
 
     public static <T> PagingResponse<T> of(Slice<T> sliceData) {
         return PagingResponse.<T>builder()
-                .data(sliceData.getContent())
+                .artistItems(sliceData.getContent())
                 .page(sliceData.getNumber())
                 .size(sliceData.getSize())
                 .totalElements(null)
@@ -41,7 +41,7 @@ public class PagingResponse<T> {
 
     public static <T> PagingResponse<T> of(List<T> data, int page, int size, long totalElements, boolean hasNext) {
         return PagingResponse.<T>builder()
-                .data(data)
+                .artistItems(data)
                 .page(page)
                 .size(size)
                 .totalElements(totalElements)

--- a/src/main/java/com/sing4u/kr/user/dto/response/UserListResponse.java
+++ b/src/main/java/com/sing4u/kr/user/dto/response/UserListResponse.java
@@ -1,5 +1,6 @@
 package com.sing4u.kr.user.dto.response;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.sing4u.kr.user.entity.User;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.*;
@@ -19,6 +20,8 @@ public class UserListResponse {
 
     @Schema(description = "프로필 이미지 URL", example = "https://example.com/profile10.jpg")
     private String profileImage;
+
+    @JsonProperty("isOpen")
     private boolean isOpen;
 
     public static UserListResponse from(User user) {


### PR DESCRIPTION
### 📌 개요
프론트 요청에 따라 API 응답 JSON 구조의 필드명을 수정하였습니다.

---

### 🔧 변경 내용
1. `PagingResponse<T>`의 `data` → `items` 로 변경
   - 기존 응답 구조의 `data.data` 중복 문제 해소
2. `UserListResponse`의 `isOpen` 필드에 `@JsonProperty("isOpen")` 추가
   - JSON 직렬화 시 `"open": true` → `"isOpen": true` 로 명시적 변경

---

### 기존 JSON 형태

---
<img width="1668" height="568" alt="image" src="https://github.com/user-attachments/assets/54094ad2-49b5-4f7d-a0bb-39d8660143f3" />
