### PR TITLE
feat: Spotify 기반 음악 검색 API 추가 (기본 market=KR)

### DIFF
--- a/src/main/java/com/sing4u/kr/music/MusicInterface.java
+++ b/src/main/java/com/sing4u/kr/music/MusicInterface.java
@@ -1,6 +1,9 @@
 package com.sing4u.kr.music;
 
 import com.sing4u.kr.music.dto.TrackDto;
+import jakarta.annotation.Nullable;
+
+import java.util.List;
 
 public interface MusicInterface {
     /**
@@ -19,4 +22,9 @@ public interface MusicInterface {
      * @return 트랙 상세 정보를 담은 {@link TrackDto}. 정보를 찾지 못하거나 오류 발생 시 null을 반환.
      */
     TrackDto getTrackDetails(String platformTrackId);
+
+    /** 플랫폼별 검색 */
+    default List<TrackDto> searchTracks(String query, int limit, int offset, @Nullable String market) {
+        throw new UnsupportedOperationException(getPlatformIdentifier() + " does not support search");
+    }
 }

--- a/src/main/java/com/sing4u/kr/music/controller/MusicSearchController.java
+++ b/src/main/java/com/sing4u/kr/music/controller/MusicSearchController.java
@@ -1,0 +1,42 @@
+package com.sing4u.kr.music.controller;
+
+import com.sing4u.kr.common.dto.ResponseResult;
+import com.sing4u.kr.common.enums.ResponseCode;
+import com.sing4u.kr.common.exception.ApiException;
+import com.sing4u.kr.music.MusicInterface;
+import com.sing4u.kr.music.MusicPlatformFactory;
+import com.sing4u.kr.music.dto.TrackDto;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/v1/music")
+@RequiredArgsConstructor
+public class MusicSearchController {
+    private final MusicPlatformFactory platformFactory;
+
+    @Operation(summary = "곡 검색", description = "플랫폼 연동을 통해 곡을 검색합니다. (현재는 SPOTIFY만).")
+    @GetMapping("/search")
+    public ResponseResult<List<TrackDto>> searchTracks(
+            @Parameter(description = "검색어 (예: 'Golden')") @RequestParam @NotBlank String q,
+            @Parameter(description = "플랫폼 식별자 (기본: SPOTIFY)") @RequestParam(defaultValue = "SPOTIFY") String platform,
+            @Parameter(description = "가져올 개수 (1~50)") @RequestParam(defaultValue = "10") @Min(1) @Max(50) int limit,
+            @Parameter(description = "페이지 오프셋 (0부터)") @RequestParam(defaultValue = "0") @Min(0) int offset
+    ) {
+        MusicInterface svc = platformFactory.getService(platform)
+                .orElseThrow(() -> new ApiException("INVALID_PLATFORM", "지원하지 않는 플랫폼: " + platform));
+
+        List<TrackDto> items = svc.searchTracks(q, limit, offset, null);
+        return new ResponseResult<>(ResponseCode.SUCCESS, items);
+    }
+}

--- a/src/main/java/com/sing4u/kr/music/spotify/SpotifyMusicService.java
+++ b/src/main/java/com/sing4u/kr/music/spotify/SpotifyMusicService.java
@@ -1,5 +1,6 @@
 package com.sing4u.kr.music.spotify; // 사용자님의 패키지 경로
 
+import com.neovisionaries.i18n.CountryCode;
 import com.sing4u.kr.music.MusicInterface; // 사용자님의 인터페이스 경로
 import com.sing4u.kr.music.dto.TrackDto;    // 공통 DTO 경로
 import jakarta.annotation.PostConstruct;
@@ -11,11 +12,15 @@ import se.michaelthelin.spotify.SpotifyApi;
 import se.michaelthelin.spotify.exceptions.SpotifyWebApiException;
 import se.michaelthelin.spotify.model_objects.credentials.ClientCredentials;
 import se.michaelthelin.spotify.model_objects.specification.ArtistSimplified;
+import se.michaelthelin.spotify.model_objects.specification.Paging;
 import se.michaelthelin.spotify.model_objects.specification.Track;
+import se.michaelthelin.spotify.requests.data.search.simplified.SearchTracksRequest;
 
 import java.io.IOException;
 import java.time.Instant;
 import java.util.Arrays;
+import java.util.List;
+import java.util.Locale;
 import java.util.stream.Collectors;
 
 @Service("spotifyMusicService")
@@ -97,5 +102,46 @@ public class SpotifyMusicService implements MusicInterface {
         }
 
         return null;
+    }
+
+    @Override
+    public List<TrackDto> searchTracks(String query, int limit, int offset, String market) {
+        try {
+            SearchTracksRequest.Builder builder = spotifyApi.searchTracks(query).limit(limit).offset(offset);
+
+            CountryCode code = CountryCode.KR; // 기본값 KR
+            if (market != null && !market.isBlank()) {
+                try {
+                    code = CountryCode.valueOf(market.trim().toUpperCase(Locale.ROOT));
+                } catch (IllegalArgumentException e) {
+                    logger.warn("Unknown market code '{}', falling back to KR.", market);
+                }
+            }
+            builder.market(code);
+
+            Paging<Track> paging = builder.build().execute();
+
+            return Arrays.stream(paging.getItems())
+                    .map(t -> {
+                        String artistNames = Arrays.stream(t.getArtists())
+                                .map(ArtistSimplified::getName)
+                                .collect(Collectors.joining(", "));
+                        return TrackDto.builder()
+                                .platformTrackId(t.getId())
+                                .title(t.getName())
+                                .artistName(artistNames)
+                                .platformName(getPlatformIdentifier())
+                                .build();
+                    })
+                    .collect(Collectors.toList());
+        } catch (SpotifyWebApiException e) {
+            logger.error("Spotify API error on searchTracks('{}'): {}", query, e.getMessage());
+            accessToken();
+        } catch (IOException e) {
+            logger.error("I/O error: {}", e.getMessage());
+        } catch (Exception e) {
+            logger.error("Unexpected error", e);
+        }
+        return List.of();
     }
 }

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -71,6 +71,7 @@ endpoints:
     - /api/v1/swagger/auth
     - /api/v1/auth/refresh
     - /api/v1/users/{publicId}
+    - /api/v1/music/search
 
 sing4u:
   server-url: http://localhost:8080


### PR DESCRIPTION
## 주요 변경사항

- music 패키지에 검색 전용 컨트롤러 추가

  - `MusicSearchController` (GET /api/v1/music/search)

  - 파라미터: q(필수), limit(기본 10, 1~50), offset(기본 0), platform(기본 SPOTIFY)

- `MusicInterface`에 검색 메소드 시그니처 추가

  - `default List<TrackDto> searchTracks(...)` (미구현 플랫폼은 UnsupportedOperationException)

- `SpotifyMusicService`에서 검색 구현

  - `spotifyApi.searchTracks(query).limit(limit).offset(offset).market(code)` 사용

  - market이 null/blank/잘못된 코드면 KR로 폴백
## 파일 추가/변경 내역 (요약)
`com.sing4u.kr.music.MusicSearchController` (신규)

`com.sing4u.kr.music.MusicInterface` (검색 시그니처 추가)

`com.sing4u.kr.music.spotify.SpotifyMusicService` (검색 구현)
