### PR TITLE
feat(auth): 비밀번호 찾기(이메일 인증)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -88,6 +88,11 @@ dependencies {
 	testImplementation 'org.mybatis.spring.boot:mybatis-spring-boot-starter-test:3.0.4'
 	testImplementation 'org.springframework.security:spring-security-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+
+	implementation 'org.springframework.boot:spring-boot-starter-mail'
+
+	// Caffeine
+	implementation 'com.github.ben-manes.caffeine:caffeine:3.1.8'
 }
 
 def querydslGenerated = layout.buildDirectory.dir("generated/sources/annotationProcessor/java/main").get().asFile

--- a/src/main/java/com/sing4u/kr/auth/config/PasswordResetCacheConfig.java
+++ b/src/main/java/com/sing4u/kr/auth/config/PasswordResetCacheConfig.java
@@ -1,0 +1,35 @@
+package com.sing4u.kr.auth.config;
+
+import com.github.benmanes.caffeine.cache.Cache;
+import com.github.benmanes.caffeine.cache.Caffeine;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import java.time.Duration;
+
+@Configuration
+public class PasswordResetCacheConfig {
+    @Bean
+    public Cache<String, String> otpCodeCache() {
+        return Caffeine.newBuilder()
+                .expireAfterWrite(Duration.ofMinutes(3))   // 인증코드 3분
+                .maximumSize(5_000)
+                .build();
+    }
+
+    @Bean
+    public Cache<String, String> throttleCache() {
+        return Caffeine.newBuilder()
+                .expireAfterWrite(Duration.ofSeconds(30)) // 재요청 제한 30초
+                .maximumSize(5_000)
+                .build();
+    }
+
+    @Bean
+    public Cache<String, String> resetTicketCache() {
+        return Caffeine.newBuilder()
+                .expireAfterWrite(Duration.ofMinutes(10)) // 리셋 토큰 10분
+                .maximumSize(5_000)
+                .build();
+    }
+}

--- a/src/main/java/com/sing4u/kr/auth/controller/AuthController.java
+++ b/src/main/java/com/sing4u/kr/auth/controller/AuthController.java
@@ -2,7 +2,11 @@ package com.sing4u.kr.auth.controller;
 
 import com.sing4u.kr.auth.dto.LoginDto;
 import com.sing4u.kr.auth.dto.request.LoginRequest;
+import com.sing4u.kr.auth.dto.request.PasswordResetConfirmRequest;
+import com.sing4u.kr.auth.dto.request.PasswordResetSendCodeRequest;
+import com.sing4u.kr.auth.dto.request.PasswordResetVerifyRequest;
 import com.sing4u.kr.auth.dto.response.LoginResponse;
+import com.sing4u.kr.auth.dto.response.SendCodeResponse;
 import com.sing4u.kr.auth.dto.response.TokenDto;
 import com.sing4u.kr.auth.dto.response.TokenResponse;
 import com.sing4u.kr.auth.service.AuthService;
@@ -13,6 +17,7 @@ import com.sing4u.kr.common.enums.ResponseCode;
 import io.swagger.v3.oas.annotations.Operation;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -25,6 +30,7 @@ import org.springframework.web.bind.annotation.RestController;
 public class AuthController {
 
     private final AuthService authService;
+    private final AuthService service;
 
     @PostMapping("/login/email")
     public ResponseResult<LoginResponse> emailLogin(@RequestBody LoginRequest request,
@@ -57,4 +63,53 @@ public class AuthController {
         return new ResponseResult<>(ResponseCode.SUCCESS);
     }
 
+    @Operation(
+            summary = "인증번호 전송 (3분 유효, 30초 재전송 제한)",
+            description = """
+            입력한 이메일로 6자리 인증번호를 전송합니다.
+            동일 이메일 재전송은 30초 제한이 있습니다.
+            
+            에러 코드
+            - 1201: 재전송 제한(잠시 후 다시 시도)
+            - 1205: SNS 간편가입 계정
+            """
+    )
+    @PostMapping("/password-reset/code")
+    public ResponseResult<SendCodeResponse> sendCode(@RequestBody @Valid PasswordResetSendCodeRequest req) {
+        SendCodeResponse data = service.sendPasswordResetCode(req.getEmail());
+        return new ResponseResult<>(ResponseCode.SUCCESS, data);
+    }
+
+
+    @Operation(
+            summary = "인증번호 검증 (성공 시 resetToken 발급)",
+            description = """
+            이메일과 6자리 인증번호를 검증합니다.
+            성공 시 10분 유효의 resetToken을 반환합니다.
+            
+            에러 코드
+            - 1202: 코드 만료
+            - 1203: 코드 불일치
+            """
+    )
+    @PostMapping("/password-reset/verify")
+    public ResponseResult<String> verify(@RequestBody @Valid PasswordResetVerifyRequest req) {
+        String ticket = service.verifyPasswordResetCode(req.getEmail(), req.getCode());
+        return new ResponseResult<>(ResponseCode.SUCCESS, ticket);
+    }
+
+    @Operation(
+            summary = "비밀번호 변경(이메일 인증 후)",
+            description = """
+            email + resetToken + newPassword 를 전달하여 비밀번호를 최종 변경합니다.
+            
+            에러 코드
+            - 1204: resetToken 불일치 또는 만료
+            """
+    )
+    @PostMapping("/password-reset/confirm")
+    public ResponseResult<Void> confirm(@RequestBody @Valid PasswordResetConfirmRequest req) {
+        service.confirmPasswordReset(req.getEmail(), req.getResetToken(), req.getNewPassword());
+        return new ResponseResult<>(ResponseCode.SUCCESS);
+    }
 }

--- a/src/main/java/com/sing4u/kr/auth/dto/request/PasswordResetConfirmRequest.java
+++ b/src/main/java/com/sing4u/kr/auth/dto/request/PasswordResetConfirmRequest.java
@@ -1,0 +1,31 @@
+package com.sing4u.kr.auth.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class PasswordResetConfirmRequest {
+    @NotBlank
+    @Email
+    private String email;
+
+    @NotBlank
+    private String resetToken;
+
+    @Schema(description = "새로운 비밀번호", example = "new_password456!")
+    @NotBlank(message = "비밀번호는 필수입니다.")
+    @Size(min = 8, max = 16, message = "비밀번호는 8자 이상 16자 이하여야 합니다.")
+    @Pattern(
+            regexp = "^(?=.*[a-zA-Z])(?=.*\\d)(?=.*[!@#$%^&*()_+=-]).{8,16}$",
+            message = "비밀번호는 영문자, 숫자, 특수문자, 숫자를 포함해 8~16자여야 합니다."
+    )
+    private String newPassword;
+}

--- a/src/main/java/com/sing4u/kr/auth/dto/request/PasswordResetSendCodeRequest.java
+++ b/src/main/java/com/sing4u/kr/auth/dto/request/PasswordResetSendCodeRequest.java
@@ -1,0 +1,16 @@
+package com.sing4u.kr.auth.dto.request;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class PasswordResetSendCodeRequest {
+    @NotBlank
+    @Email
+    private String email;
+}

--- a/src/main/java/com/sing4u/kr/auth/dto/request/PasswordResetVerifyRequest.java
+++ b/src/main/java/com/sing4u/kr/auth/dto/request/PasswordResetVerifyRequest.java
@@ -1,0 +1,21 @@
+package com.sing4u.kr.auth.dto.request;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class PasswordResetVerifyRequest {
+    @NotBlank
+    @Email
+    private String email;
+
+    @NotBlank
+    @Pattern(regexp = "\\d{6}") // 6자리 숫자
+    private String code;
+}

--- a/src/main/java/com/sing4u/kr/auth/dto/response/SendCodeResponse.java
+++ b/src/main/java/com/sing4u/kr/auth/dto/response/SendCodeResponse.java
@@ -1,0 +1,23 @@
+package com.sing4u.kr.auth.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+/**
+ * 프론트 타이머/마스킹 표시용 응답 DTO
+ */
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class SendCodeResponse {
+    // 인증번호 유효 시간(초) — 기본 180
+    private int expiresIn;
+
+    // 재전송 가능 대기 시간(초) — 기본 30
+    private int resendAvailableIn;
+
+    // 마스킹된 이메일
+    private String maskedEmail;
+}

--- a/src/main/java/com/sing4u/kr/auth/repository/PasswordResetTokenRepository.java
+++ b/src/main/java/com/sing4u/kr/auth/repository/PasswordResetTokenRepository.java
@@ -1,0 +1,17 @@
+package com.sing4u.kr.auth.repository;
+
+public interface PasswordResetTokenRepository {
+    // OTP 코드 (3분)
+    void saveCode(String email, String code);
+    String getCode(String email);
+    void removeCode(String email);
+
+    // 30초 재요청 제한
+    boolean isThrottled(String email);
+    void throttle(String email);
+
+    // 리셋 토큰 (10분)
+    void saveTicket(String email, String ticket);
+    String getTicket(String email);
+    void removeTicket(String email);
+}

--- a/src/main/java/com/sing4u/kr/auth/repository/impl/CaffeinePasswordResetTokenRepository.java
+++ b/src/main/java/com/sing4u/kr/auth/repository/impl/CaffeinePasswordResetTokenRepository.java
@@ -1,0 +1,39 @@
+package com.sing4u.kr.auth.repository.impl;
+
+import com.github.benmanes.caffeine.cache.Cache;
+import com.sing4u.kr.auth.repository.PasswordResetTokenRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public class CaffeinePasswordResetTokenRepository implements PasswordResetTokenRepository {
+    private final Cache<String, String> otp;
+    private final Cache<String, String> thr;
+    private final Cache<String, String> tkt;
+
+    public CaffeinePasswordResetTokenRepository(
+            @Qualifier("otpCodeCache") Cache<String, String> otp,
+            @Qualifier("throttleCache") Cache<String, String> thr,
+            @Qualifier("resetTicketCache") Cache<String, String> tkt
+    ) {
+        this.otp = otp;
+        this.thr = thr;
+        this.tkt = tkt;
+    }
+
+    private String ck(String email){ return "code:"+email; }
+    private String tk(String email){ return "tkt:"+email; }
+    private String hk(String email){ return "thr:"+email; }
+
+    @Override public void saveCode(String email, String code) { otp.put(ck(email), code); }
+    @Override public String getCode(String email) { return otp.getIfPresent(ck(email)); }
+    @Override public void removeCode(String email) { otp.invalidate(ck(email)); }
+
+    @Override public boolean isThrottled(String email) { return thr.getIfPresent(hk(email)) != null; }
+    @Override public void throttle(String email) { thr.put(hk(email), "1"); }
+
+    @Override public void saveTicket(String email, String ticket) { tkt.put(tk(email), ticket); }
+    @Override public String getTicket(String email) { return tkt.getIfPresent(tk(email)); }
+    @Override public void removeTicket(String email) { tkt.invalidate(tk(email)); }
+}

--- a/src/main/java/com/sing4u/kr/auth/service/AuthService.java
+++ b/src/main/java/com/sing4u/kr/auth/service/AuthService.java
@@ -1,18 +1,22 @@
 package com.sing4u.kr.auth.service;
 
+import com.sing4u.kr.auth.dto.response.SendCodeResponse;
 import com.sing4u.kr.auth.entity.RefreshToken;
 import com.sing4u.kr.auth.dto.LoginDto;
 import com.sing4u.kr.auth.dto.request.LoginRequest;
 import com.sing4u.kr.auth.dto.response.TokenDto;
+import com.sing4u.kr.auth.repository.PasswordResetTokenRepository;
 import com.sing4u.kr.auth.repository.RefreshTokenRepository;
 import com.sing4u.kr.common.enums.ResponseCode;
 import com.sing4u.kr.common.exception.Exception400;
 import com.sing4u.kr.jwt.exceptions.InvalidTokenException;
 import com.sing4u.kr.jwt.model.JwtToken;
 import com.sing4u.kr.jwt.provider.JwtTokenProvider;
+import com.sing4u.kr.mail.service.MailService;
 import com.sing4u.kr.user.entity.User;
 import com.sing4u.kr.user.entity.enums.UserType;
 import com.sing4u.kr.user.enums.UserRole;
+import com.sing4u.kr.user.entity.enums.SocialType;
 import com.sing4u.kr.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -22,6 +26,8 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.util.Date;
 import java.util.List;
+import java.util.UUID;
+import java.util.concurrent.ThreadLocalRandom;
 
 @Slf4j
 @Service
@@ -32,6 +38,12 @@ public class AuthService {
     private final PasswordEncoder passwordEncoder;
     private final JwtTokenProvider jwtTokenProvider;
     private final RefreshTokenRepository refreshTokenRepository;
+    private final PasswordResetTokenRepository passwordResetTokens;        // Caffeine 저장소 (code/throttle/ticket)
+    private final MailService mailService;                                 // SMTP 메일 발송
+
+    // 프론트 타이머 표시용(값만 응답에 내려줌. 실제 TTL은 Caffeine Bean에서 관리)
+    private static final int CODE_EXPIRES_SECONDS = 180;   // 3분
+    private static final int RESEND_THROTTLE_SECONDS = 30; // 30초
 
     @Transactional
     public LoginDto emailLogin(LoginRequest request) {
@@ -102,5 +114,93 @@ public class AuthService {
     @Transactional
     public void logout(Long userId) {
         refreshTokenRepository.deleteByUserId(userId);
+    }
+
+    /**
+     * 인증번호 전송: 6자리 코드 생성 → Caffeine에 3분 저장, 30초 재요청 제한 → 이메일 발송
+     */
+    @Transactional(readOnly = true)
+    public SendCodeResponse sendPasswordResetCode(String email) {
+        // 가입 여부 확인
+        User user = userRepository.findByEmailAndDeletedAtIsNull(email)
+                .orElseThrow(() -> new Exception400(ResponseCode.ERROR_USER_NOT_FOUND));
+
+        // 소셜 전용 계정 차단
+        if (user.getSocialType() != null && user.getSocialType() != SocialType.LOCAL) {
+            throw new Exception400(ResponseCode.PASSWORD_RESET_SOCIAL_ACCOUNT);
+        }
+
+        // 30초 재요청 제한
+        if (passwordResetTokens.isThrottled(email)) {
+            throw new Exception400(ResponseCode.PASSWORD_RESET_RESEND_THROTTLED);
+        }
+
+        // 6자리 숫자 코드
+        String code = String.format("%06d", ThreadLocalRandom.current().nextInt(0, 1_000_000));
+
+        // 저장 (TTL/만료는 Caffeine Bean 설정)
+        passwordResetTokens.saveCode(email, code);
+        passwordResetTokens.throttle(email);
+
+        // 메일 발송
+        String subject = "[Sing4U] 비밀번호 재설정 인증번호";
+        String body = """
+                인증번호: %s
+                유효 시간: 3분
+                타인에게 공유하지 마세요.
+                """.formatted(code);
+        mailService.send(email, subject, body);
+
+        return new SendCodeResponse(CODE_EXPIRES_SECONDS, RESEND_THROTTLE_SECONDS, maskEmail(email));
+    }
+
+    /**
+     * 인증번호 검증: 일치하면 일회성 resetToken 발급(10분 TTL), 코드 즉시 폐기
+     */
+    @Transactional(readOnly = true)
+    public String verifyPasswordResetCode(String email, String code) {
+        String stored = passwordResetTokens.getCode(email);
+        if (stored == null) {
+            // 만료되었거나 발송 이력이 없음
+            throw new Exception400(ResponseCode.PASSWORD_RESET_CODE_EXPIRED);
+        }
+        if (!stored.equals(code)) {
+            // 불일치
+            throw new Exception400(ResponseCode.PASSWORD_RESET_CODE_INVALID );
+        }
+
+        // 1회성 사용: 코드 삭제
+        passwordResetTokens.removeCode(email);
+
+        // resetToken 발급(난수) 및 저장(10분 TTL은 Bean에서)
+        String resetToken = UUID.randomUUID().toString();
+        passwordResetTokens.saveTicket(email, resetToken);
+        return resetToken;
+    }
+
+    /**
+     * 최종 비밀번호 변경: resetToken 검증 → 사용자 조회 → 암호화 저장 → 토큰 폐기
+     */
+    @Transactional
+    public void confirmPasswordReset(String email, String resetToken, String newPassword) {
+        String stored = passwordResetTokens.getTicket(email);
+        if (stored == null || !stored.equals(resetToken)) {
+            throw new Exception400(ResponseCode.PASSWORD_RESET_TOKEN_INVALID);
+        }
+
+        User user = userRepository.findByEmailAndDeletedAtIsNull(email)
+                .orElseThrow(() -> new Exception400(ResponseCode.ERROR_USER_NOT_FOUND));
+
+        user.updatePassword(passwordEncoder.encode(newPassword));
+        userRepository.save(user);
+
+        // 토큰 1회성 사용 후 폐기
+        passwordResetTokens.removeTicket(email);
+    }
+
+    private String maskEmail(String email) {
+        int at = email.indexOf('@');
+        if (at <= 1) return "***";
+        return email.charAt(0) + "***" + email.substring(at);
     }
 }

--- a/src/main/java/com/sing4u/kr/common/enums/ResponseCode.java
+++ b/src/main/java/com/sing4u/kr/common/enums/ResponseCode.java
@@ -26,6 +26,13 @@ public enum ResponseCode {
     ERROR_USER_NOT_FOUND("3001", "존재하지 않는 사용자 입니다"),
 
     ERROR_PASSWORD_MISMATCH("3002", "비밀번호가 일치하지 않습니다."),
+
+    PASSWORD_RESET_RESEND_THROTTLED ("1201", "Too Many Requests: 잠시 후 다시 시도해 주세요."),
+    PASSWORD_RESET_CODE_EXPIRED      ("1202", "인증번호 유효 시간이 만료되었습니다."),
+    PASSWORD_RESET_CODE_INVALID      ("1203", "인증번호가 올바르지 않습니다."),
+    PASSWORD_RESET_TOKEN_INVALID     ("1204", "인증이 만료되었거나 유효하지 않습니다."),
+    PASSWORD_RESET_SOCIAL_ACCOUNT    ("1205", "SNS로 간편 가입된 계정입니다.")
+
     ;
     private final String code;
     private final String message;

--- a/src/main/java/com/sing4u/kr/mail/service/MailService.java
+++ b/src/main/java/com/sing4u/kr/mail/service/MailService.java
@@ -1,0 +1,8 @@
+package com.sing4u.kr.mail.service;
+
+public interface MailService {
+    void send(String to, String subject, String body);               // 텍스트
+    default void sendHtml(String to, String subject, String html) {  // 필요하면 HTML
+        send(to, subject, html);
+    }
+}

--- a/src/main/java/com/sing4u/kr/mail/service/SmtpMailService.java
+++ b/src/main/java/com/sing4u/kr/mail/service/SmtpMailService.java
@@ -1,0 +1,43 @@
+package com.sing4u.kr.mail.service;
+
+import jakarta.mail.MessagingException;
+import jakarta.mail.internet.MimeMessage;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.mail.javamail.MimeMessageHelper;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class SmtpMailService implements MailService {
+    private final JavaMailSender sender;
+
+    // Gmail은 보통 username과 동일한 주소를 From으로 쓰는 게 안전
+    @Value("${mail.from:}")
+    private String from; // 비워두면 username이 자동 사용됨(메일서버 설정에 따름)
+
+    @Override
+    public void send(String to, String subject, String body) {
+        sendInternal(to, subject, body, false);
+    }
+
+    @Override
+    public void sendHtml(String to, String subject, String html) {
+        sendInternal(to, subject, html, true);
+    }
+
+    private void sendInternal(String to, String subject, String content, boolean html) {
+        try {
+            MimeMessage msg = sender.createMimeMessage();
+            MimeMessageHelper h = new MimeMessageHelper(msg, "UTF-8");
+            if (!from.isBlank()) h.setFrom(from);
+            h.setTo(to);
+            h.setSubject(subject);
+            h.setText(content, html);
+            sender.send(msg);
+        } catch (MessagingException e) {
+            throw new RuntimeException("메일 발송 실패", e);
+        }
+    }
+}

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -53,6 +53,15 @@ spring:
   #          token-uri: https://oauth2.googleapis.com/token
   #          user-info-uri: https://www.googleapis.com/oauth2/v3/userinfo
 
+  mail:
+    host: smtp.gmail.com
+    port: 587
+    username: ${MAIL_USER}
+    password: ${MAIL_PASS}
+    properties:
+      mail.smtp.auth: true
+      mail.smtp.starttls.enable: true
+
 endpoints:
   public-api-list:
     - /api/v1/health/**
@@ -71,6 +80,8 @@ endpoints:
     - /api/v1/swagger/auth
     - /api/v1/auth/refresh
     - /api/v1/users/{publicId}
+    - /api/v1/music/search
+    - /api/v1/auth/password-reset/**
 
 sing4u:
   server-url: http://localhost:8080
@@ -116,3 +127,6 @@ cookie:
 
 server:
   forward-headers-strategy: framework
+
+mail:
+  from: ${MAIL_USER}


### PR DESCRIPTION
## 개요

- 비로그인 사용자를 위한 비밀번호 재설정 플로우 추가

 1. 이메일로 6자리 인증번호 전송(유효 3분)

 2. 인증번호 검증 성공 시 resetToken(유효 10분) 발급

 3. email + resetToken + newPassword 로 최종 변경

- 캐시는 Caffeine(추후 redis 교체 고려), 메일은 Gmail SMTP(추후 SES 교체 고려)

## 주요 변경사항

- API (신규): `/api/v1/auth/password-reset/**`

  - `POST /code` – 인증번호 전송(3분, 30초 재전송 제한)

  - `POST /verify` – 인증번호 검증 → resetToken 발급(10분)

  - `POST /confirm` – 최종 비밀번호 변경

- DTO (추가)

  - `PasswordResetSendCodeRequest`, `PasswordResetVerifyRequest`, `PasswordResetConfirmRequest`

  - `SendCodeResponse`

- Service (변경): `AuthService`에 `sendPasswordResetCode`, `verifyPasswordResetCode`, `confirmPasswordReset` 추가

- Repository (추가)

  - `auth.repository.PasswordResetTokenRepository` + `impl.CaffeinePasswordResetTokenRepository`

  - 캐시 3종: `otpCodeCache`(3분), `throttleCache`(30초), `resetTicketCache`(10분)

- Config (추가): `auth.config.PasswordResetCacheConfig` (Caffeine Bean 정의)

- Controller (변경): `AuthController`

- ResponseCode (변경)

  | 코드  | 의미                                       | 권장 HTTP               |
  |-----|------------------------------------------|------------------------|
  | `1201` | 재전송 제한(30초)                         | `400 Too Many Requests` |
  | `1202` | 인증번호 만료                              | `400 Bad Request`       |
  | `1203` | 인증번호 불일치                            | `400 Bad Request`       |
  | `1204` | resetToken 불일치/만료                     | `400 Bad Request`       |
  | `1205` | SNS 간편가입 계정(이메일 비번 재설정 불가) | `400 Bad Request`       |
## 테스트 방법
### 스웨거

`/code` 호출 → 3분 이후 1202 확인 → 30초 내 재전송 시 1201 확인

`/verify` 성공 시 resetToken 수신 → `/confirm`으로 최종 비밀번호 변경