### PR TITLE
fix: SongRequest DTO/Entity에서 musicPlatformName SPOTIFY 고정

### DIFF
--- a/src/main/java/com/sing4u/kr/songRequest/dto/request/SongRequestCreateDto.java
+++ b/src/main/java/com/sing4u/kr/songRequest/dto/request/SongRequestCreateDto.java
@@ -20,8 +20,8 @@ public class SongRequestCreateDto {
     private String email;
 
     @Size(max = 20, message = "음악 플랫폼 이름은 최대 20자까지 가능합니다.")
-    @Schema(description = "음원 플랫폼 명 (정보 조회에 사용)", example = "SPOTIFY", allowableValues = {"SPOTIFY", "YOUTUBE_MUSIC"})
-    private String musicPlatformName;
+    @Schema(hidden = true) // Swagger 문서에서 숨김
+    private final String musicPlatformName = "SPOTIFY";
 
     @Size(max = 100, message = "플랫폼 트랙 ID는 최대 100자까지 가능합니다.")
     @Schema(description = "음원 플랫폼의 트랙 ID (정보 조회에 사용)", example = "4iV5W9uYEdYUVa79Axb7Rh")

--- a/src/main/java/com/sing4u/kr/songRequest/entity/SongRequest.java
+++ b/src/main/java/com/sing4u/kr/songRequest/entity/SongRequest.java
@@ -26,8 +26,8 @@ public class SongRequest {
     @Column(name = "fan_email", length = 50)
     private String fanEmail;
 
-    @Column(name = "music_platform_name", length = 20) // 예: "SPOTIFY", "YOUTUBE_MUSIC"
-    private String musicPlatformName;
+    @Column(name = "music_platform_name", length = 20) // 예: "SPOTIFY",
+    private String musicPlatformName = "SPOTIFY";
 
     @Column(name = "platform_track_id", length = 100) // 해당 플랫폼에서의 트랙 ID
     private String platformTrackId;


### PR DESCRIPTION
## 변경 내용
- SongRequestCreateDto: musicPlatformName 필드를 Swagger 문서에서 숨기고 내부적으로 "SPOTIFY"로 고정
- SongRequest Entity: musicPlatformName 컬럼을 기본값 "SPOTIFY"로 지정하여 항상 고정 저장되도록 수정

## 변경 이유
- 영구적으로 SPOTIFY만 사용
