### PR TITLE
feat-authorization update

### DIFF
--- a/src/main/java/com/sing4u/kr/songRequest/controller/SongRequestController.java
+++ b/src/main/java/com/sing4u/kr/songRequest/controller/SongRequestController.java
@@ -11,6 +11,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
@@ -25,6 +26,7 @@ public class SongRequestController {
 
     @Operation(summary = "곡 요청 제출", description = "팬이 아티스트에게 곡 요청을 제출합니다.")
     @PostMapping
+    @PreAuthorize("permitAll()")
     public ResponseResult<SongRequestResponseDto> submitSongRequest(@Valid @RequestBody SongRequestCreateDto createDto) {
         SongRequestResponseDto responseDto = songRequestService.createSongRequest(createDto);
         return new ResponseResult<>(ResponseCode.SUCCESS, responseDto);

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -72,6 +72,7 @@ endpoints:
     - /api/v1/auth/refresh
     - /api/v1/users/{publicId}
     - /api/v1/music/search
+    - /api/v1/songRequests
 
 sing4u:
   server-url: http://localhost:8080


### PR DESCRIPTION
## 변경 내용

- SecurityConfig의 public-api-list에 곡 신청 API 경로 추가
- 비회원(익명 사용자)도 POST /api/v1/song-requests 요청 가능하도록 권한 수정

## 변경 이유
- 기존 설정에서는 곡 신청 API가 인증 필요로 설정되어 있어, 비회원 신청 시