### PR TITLE
feat(auth): 비밀번호 재설정 인증번호 비동기 발송(202) + 실패 자동복구 + 429 매핑

### DIFF
--- a/src/main/java/com/sing4u/kr/application/config/AsyncConfig.java
+++ b/src/main/java/com/sing4u/kr/application/config/AsyncConfig.java
@@ -1,0 +1,23 @@
+package com.sing4u.kr.application.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.EnableAsync;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
+
+import java.util.concurrent.Executor;
+
+@Configuration
+@EnableAsync
+public class AsyncConfig {
+    @Bean(name = "mailExecutor")
+    public Executor mailExecutor() {
+        ThreadPoolTaskExecutor ex = new ThreadPoolTaskExecutor();
+        ex.setCorePoolSize(2);
+        ex.setMaxPoolSize(4);
+        ex.setQueueCapacity(100);
+        ex.setThreadNamePrefix("mail-");
+        ex.initialize();
+        return ex;
+    }
+}

--- a/src/main/java/com/sing4u/kr/auth/controller/AuthController.java
+++ b/src/main/java/com/sing4u/kr/auth/controller/AuthController.java
@@ -15,10 +15,14 @@ import com.sing4u.kr.common.auth.LoginUserId;
 import com.sing4u.kr.common.dto.ResponseResult;
 import com.sing4u.kr.common.enums.ResponseCode;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -74,10 +78,17 @@ public class AuthController {
             - 1205: SNS 간편가입 계정
             """
     )
+    @ApiResponses({
+            @ApiResponse(responseCode = "202", description = "요청 접수(메일 발송 비동기)"),
+            @ApiResponse(responseCode = "429", description = "재전송 제한(30초)"),
+            @ApiResponse(responseCode = "400", description = "요청 오류 / SNS 간편가입 계정 등")
+    })
     @PostMapping("/password-reset/code")
-    public ResponseResult<SendCodeResponse> sendCode(@RequestBody @Valid PasswordResetSendCodeRequest req) {
+    public ResponseEntity<ResponseResult<SendCodeResponse>> sendCode(@RequestBody @Valid PasswordResetSendCodeRequest req) {
         SendCodeResponse data = service.sendPasswordResetCode(req.getEmail());
-        return new ResponseResult<>(ResponseCode.SUCCESS, data);
+        return ResponseEntity
+                .status(HttpStatus.ACCEPTED) // 202
+                .body(new ResponseResult<>(ResponseCode.SUCCESS, data));
     }
 
 

--- a/src/main/java/com/sing4u/kr/auth/event/PasswordResetCodeIssuedEvent.java
+++ b/src/main/java/com/sing4u/kr/auth/event/PasswordResetCodeIssuedEvent.java
@@ -1,0 +1,3 @@
+package com.sing4u.kr.auth.event;
+
+public record PasswordResetCodeIssuedEvent(String email, String code) { }

--- a/src/main/java/com/sing4u/kr/auth/mail/PasswordResetMailerListener.java
+++ b/src/main/java/com/sing4u/kr/auth/mail/PasswordResetMailerListener.java
@@ -1,0 +1,33 @@
+package com.sing4u.kr.auth.mail;
+
+import com.sing4u.kr.auth.event.PasswordResetCodeIssuedEvent;
+import com.sing4u.kr.auth.repository.PasswordResetTokenRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class PasswordResetMailerListener {
+
+    private final PasswordResetMailer mailer;
+    private final PasswordResetTokenRepository passwordResetTokens;
+
+    @Async("mailExecutor")
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void on(PasswordResetCodeIssuedEvent e) {
+        try {
+            mailer.send(e.email(), e.code());
+        } catch (Exception ex) {
+            log.error("Password reset mail send failed. email={}, err={}", e.email(), ex.toString(), ex);
+            // 실패 시: 사용자가 바로 재전송 가능하도록 복구
+            passwordResetTokens.removeCode(e.email());     // 발급된 인증코드 무효화
+            passwordResetTokens.clearThrottle(e.email());  // 30초 쿨다운 즉시 해제
+            log.info("[MAIL][LISTENER] rollback cleared code & throttle for {}", e.email());
+        }
+    }
+}

--- a/src/main/java/com/sing4u/kr/auth/repository/PasswordResetTokenRepository.java
+++ b/src/main/java/com/sing4u/kr/auth/repository/PasswordResetTokenRepository.java
@@ -9,6 +9,8 @@ public interface PasswordResetTokenRepository {
     // 30초 재요청 제한
     boolean isThrottled(String email);
     void throttle(String email);
+    // 쿨다운 강제 해제
+    void clearThrottle(String email);
 
     // 리셋 토큰 (10분)
     void saveTicket(String email, String ticket);

--- a/src/main/java/com/sing4u/kr/auth/repository/impl/CaffeinePasswordResetTokenRepository.java
+++ b/src/main/java/com/sing4u/kr/auth/repository/impl/CaffeinePasswordResetTokenRepository.java
@@ -32,6 +32,7 @@ public class CaffeinePasswordResetTokenRepository implements PasswordResetTokenR
 
     @Override public boolean isThrottled(String email) { return thr.getIfPresent(hk(email)) != null; }
     @Override public void throttle(String email) { thr.put(hk(email), "1"); }
+    @Override public void clearThrottle(String email) { thr.invalidate(hk(email)); }
 
     @Override public void saveTicket(String email, String ticket) { tkt.put(tk(email), ticket); }
     @Override public String getTicket(String email) { return tkt.getIfPresent(tk(email)); }

--- a/src/main/java/com/sing4u/kr/auth/service/AuthService.java
+++ b/src/main/java/com/sing4u/kr/auth/service/AuthService.java
@@ -5,6 +5,7 @@ import com.sing4u.kr.auth.entity.RefreshToken;
 import com.sing4u.kr.auth.dto.LoginDto;
 import com.sing4u.kr.auth.dto.request.LoginRequest;
 import com.sing4u.kr.auth.dto.response.TokenDto;
+import com.sing4u.kr.auth.event.PasswordResetCodeIssuedEvent;
 import com.sing4u.kr.auth.mail.PasswordResetMailer;
 import com.sing4u.kr.auth.repository.PasswordResetTokenRepository;
 import com.sing4u.kr.auth.repository.RefreshTokenRepository;
@@ -21,6 +22,7 @@ import com.sing4u.kr.user.entity.enums.SocialType;
 import com.sing4u.kr.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -41,6 +43,7 @@ public class AuthService {
     private final RefreshTokenRepository refreshTokenRepository;
     private final PasswordResetTokenRepository passwordResetTokens;        // Caffeine 저장소 (code/throttle/ticket)
     private final PasswordResetMailer passwordResetMailer;                               // SMTP 메일 발송
+    private final ApplicationEventPublisher publisher;
 
     // 프론트 타이머 표시용(값만 응답에 내려줌. 실제 TTL은 Caffeine Bean에서 관리)
     private static final int CODE_EXPIRES_SECONDS = 180;   // 3분
@@ -143,8 +146,8 @@ public class AuthService {
         passwordResetTokens.saveCode(email, code);
         passwordResetTokens.throttle(email);
 
-        // 메일 발송
-        passwordResetMailer.send(email, code);
+        // 메일 발송(비동기 이벤트)
+        publisher.publishEvent(new PasswordResetCodeIssuedEvent(email, code));
 
         return new SendCodeResponse(CODE_EXPIRES_SECONDS, RESEND_THROTTLE_SECONDS, maskEmail(email));
     }

--- a/src/main/java/com/sing4u/kr/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/sing4u/kr/common/exception/GlobalExceptionHandler.java
@@ -102,9 +102,18 @@ public class GlobalExceptionHandler {
     @ExceptionHandler(value = {
             Exception400.class,
     })
-    public ResponseResult handleException400(ApiException e) {
-        log.error("", e);
-        return new ResponseResult<>(e.getCode(), e.getMessage(), null);
+//    public ResponseResult handleException400(ApiException e) {
+//        log.error("", e);
+//        return new ResponseResult<>(e.getCode(), e.getMessage(), null);
+//    }
+    public ResponseEntity<ResponseResult<?>> handleException400(Exception400 e) {
+        // 스로틀(1201)만 429, 나머지는 400
+        HttpStatus status = ResponseCode.PASSWORD_RESET_RESEND_THROTTLED.getCode().equals(e.getCode())
+                ? HttpStatus.TOO_MANY_REQUESTS   // 429
+                : HttpStatus.BAD_REQUEST;        // 400
+
+        return ResponseEntity.status(status)
+                .body(new ResponseResult<>(e.getCode(), e.getMessage(), null));
     }
 
     @ResponseStatus(HttpStatus.CONFLICT)

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -61,6 +61,9 @@ spring:
     properties:
       mail.smtp.auth: true
       mail.smtp.starttls.enable: true
+      mail.smtp.connection timeout: 3000   # 서버 연결 시도 타임아웃
+      mail.smtp.timeout: 5000              # 읽기(응답 대기) 타임아웃
+      mail.smtp.write timeout: 5000        # 쓰기(전송) 타임아웃
 
 endpoints:
   public-api-list:


### PR DESCRIPTION
### 요약

- 비밀번호 재설정 “인증번호 전송”을 비동기 처리로 전환

- API는 즉시 202 Accepted로 “요청 접수”를 반환하고, 메일 발송은 백그라운드에서 수행

- 발송 실패 시 인증코드 삭제 + 30초 쿨다운 해제로 사용자가 바로 재전송할 수 있도록 복구

- 재전송 제한은 HTTP 429로 내려가도록 전역 예외 핸들러를 조정

- Swagger 문서에 202/429 응답 명시
-----

### 변경 사항
#### 신규
- `auth.event.PasswordResetCodeIssuedEvent`

- `auth.mail.PasswordResetMailerListener`
  - `@Async("mailExecutor")` + `@TransactionalEventListener(AFTER_COMMIT)`

  - try/catch로 메일 전송 실패를 내부에서 처리:

    - 실패 시: `removeCode(email)` + `clearThrottle(email)` (즉시 재전송 가능)

    - 성공/실패 로그 추가

- `application.config.AsyncConfig`
#### 수정
- `auth.controller.AuthController`

  - 반환 타입 → `ResponseEntity<ResponseResult<SendCodeResponse>>`

  - HTTP 상태코드 → 202 Accepted

- `auth.service.AuthService`

  - `sendPasswordResetCode`에서 이벤트 발행

- `auth.repository.PasswordResetTokenRepository`

  - `clearThrottle(String email)` 추가

- `auth.repository.impl.CaffeinePasswordResetTokenRepository`

  - `clearThrottle` 구현

- `common.exception.GlobalExceptionHandler`

  - `handleException400(Exception400 e)` → `ResponseEntity` 사용, 1201→429 분기
----
### 테스트 시나리오

1. 정상 발송

    - `POST /password-reset/code` → **202**

    - (메일 서버 정상) → 실제 메일 수신

    - 30초 내 재요청 → **429**

    - 30초 이후 재요청 → **202**

2. 발송 실패 복구(SMTP 비밀번호를 일부러 틀리게 해놓고)

    - `POST /password-reset/code` → **202**

    - 리스너에서 실패 로그 + 코드 삭제 & 쿨다운 해제

    - 1초 후 재요청 → **202 _(429가 아니어야 함)_**

3. 검증·확정(기존 유지)