### PR TITLE
곡 요청 목록 조회 API - 곡이 없는 세션 제거 : 빈 신청곡 예외 처리

### DIFF
--- a/src/main/java/com/sing4u/kr/songRequest/service/SongRequestService.java
+++ b/src/main/java/com/sing4u/kr/songRequest/service/SongRequestService.java
@@ -172,6 +172,8 @@ public class SongRequestService {
                             .collect(Collectors.toList());
                     return SessionSongsDto.from(session, songDetails);
                 })
+                // 아무것도 없는 신청곡은 제외
+                .filter(dto -> dto.getSongs() != null && !dto.getSongs().isEmpty())
                 .collect(Collectors.toList());
     }
 }


### PR DESCRIPTION

현재 아티스트 곡 요청 목록 조회 API에서 반환되는 응답에는, 곡 요청(songs)이 없는 세션도 포함되어

필터 처리 작업