### PR TITLE
refactor: 홈 아티스트 캐시 제거 및 @Builder.Default 추가로 빌드 경고 제거

### DIFF
--- a/src/main/java/com/sing4u/kr/home/dto/request/HomeRequest.java
+++ b/src/main/java/com/sing4u/kr/home/dto/request/HomeRequest.java
@@ -10,5 +10,7 @@ import lombok.*;
 public class HomeRequest {
     private String keyword;
     private int page;
+
+    @Builder.Default
     private int pageSize = 12;
 }

--- a/src/main/java/com/sing4u/kr/songRequest/entity/SongRequest.java
+++ b/src/main/java/com/sing4u/kr/songRequest/entity/SongRequest.java
@@ -26,6 +26,7 @@ public class SongRequest {
     @Column(name = "fan_email", length = 50)
     private String fanEmail;
 
+    @Builder.Default
     @Column(name = "music_platform_name", length = 20) // 예: "SPOTIFY",
     private String musicPlatformName = "SPOTIFY";
 

--- a/src/main/java/com/sing4u/kr/user/service/UserService.java
+++ b/src/main/java/com/sing4u/kr/user/service/UserService.java
@@ -41,11 +41,11 @@ public class UserService {
     private final PasswordEncoder passwordEncoder;
     private final S3Service s3Service;
 
-    @Cacheable(
-            value = "homeArtists",
-            key = "'page=' + #request.page + ',size=' + #request.pageSize",
-            condition = "#request.keyword == null || #request.keyword.trim().isEmpty()"
-    )
+//    @Cacheable(
+//            value = "homeArtists",
+//            key = "'page=' + #request.page + ',size=' + #request.pageSize",
+//            condition = "#request.keyword == null || #request.keyword.trim().isEmpty()"
+//    )
     @Transactional(readOnly = true)
     public PagingResponse<UserListResponse> getArtistList(HomeRequest request) {
         Pageable pageable = PageRequest.of(request.getPage(), request.getPageSize());
@@ -55,11 +55,11 @@ public class UserService {
         return PagingResponse.of(responseSlice);
     }
 
-    @CacheEvict(
-            value = "homeArtists",
-            allEntries = true,
-            condition = "#request.userType == T(com.sing4u.kr.user.entity.enums.UserType).ARTIST"
-    )
+//    @CacheEvict(
+//            value = "homeArtists",
+//            allEntries = true,
+//            condition = "#request.userType == T(com.sing4u.kr.user.entity.enums.UserType).ARTIST"
+//    )
     @Transactional
     public UserCreateResponse createUser(UserCreateRequest request) {
         User user = User.of(request.getNickname(), request.getEmail(), passwordEncoder.encode(request.getPassword()), request.getUserType());
@@ -80,7 +80,7 @@ public class UserService {
         userRepository.save(user);
     }
 
-    @CacheEvict(value = "homeArtists", allEntries = true)
+    //@CacheEvict(value = "homeArtists", allEntries = true)
     @Transactional
     public UserProfileResponse updateProfile(Long id, UserUpdateProfileRequest request) {
         User user = getEntityOrThrow(id);
@@ -145,7 +145,7 @@ public class UserService {
         //return UserUpdatePasswordResponse.from(user);
     }
 
-    @CacheEvict(value = "homeArtists", allEntries = true)
+    //@CacheEvict(value = "homeArtists", allEntries = true)
     @Transactional
     public void deleteUser(Long id) {
         User user = getEntityOrThrow(id);
@@ -158,7 +158,7 @@ public class UserService {
                 .orElseThrow(() -> new Exception400("사용자를 찾을 수 없습니다.", ResponseCode.ERROR_NO_DATA));
     }
 
-    @CacheEvict(value = "homeArtists", allEntries = true)
+    //@CacheEvict(value = "homeArtists", allEntries = true)
     @Transactional
     public UserUpdateProfileImageResponse updateUserProfileImage(Long id, MultipartFile file) {
         User user = this.getEntityOrThrow(id);
@@ -181,7 +181,7 @@ public class UserService {
         return user.getId();
     }
 
-    @CacheEvict(value = "homeArtists", allEntries = true)
+    //@CacheEvict(value = "homeArtists", allEntries = true)
     @Transactional
     public void deleteUserProfileImage(Long id) {
         User user = this.getEntityOrThrow(id);


### PR DESCRIPTION
### 변경 내용
1. 홈 아티스트 리스트 캐시 관련 어노테이션 주석 처리
   - UserService.getArtistList()의 @Cacheable("homeArtists") 주석 처리
   - 관련된 @CacheEvict("homeArtists") 주석 처리
   - 세션 오픈/종료 시 즉시 캐시 제거

2. Lombok @Builder.Default 추가
   - SongRequest.musicPlatformName 필드에 @Builder.Default 추가 (기본값 "SPOTIFY")
   - HomeRequest.pageSize 필드에 @Builder.Default 추가 (기본값 12)
   - Lombok @Builder가 필드 초기값을 무시해 발생하던 빌드 경고 제거
   - 빌더 생성 시에도 기본값이 정상 반영되도록 수정

### 배경
- 캐시: 홈 화면 아티스트 리스트에 세션 오픈/종료 상태(isOpen)가 즉시 반영되지 않는 문제가 있었음
- 빌드: @Builder 기본값 무시 경고가 발생하여 불필요한 컴파일 경고 노출

### 차후 고려
- 트래픽 증가 시 캐시 재도입 가능
