### PR TITLE
세션 상태 조회 API 해결

### DIFF
--- a/src/main/java/com/sing4u/kr/session/controller/SessionController.java
+++ b/src/main/java/com/sing4u/kr/session/controller/SessionController.java
@@ -58,9 +58,10 @@ public class SessionController {
 
         User user = userRepository.findByUserPublicIdAndDeletedAtIsNull(artistPublicId)
                 .orElseThrow(() -> new ApiException(ExceptionCode.NOT_FOUND, "아티스트를 찾을 수 없습니다."));
-        Boolean sessionOpenClose =  user.isOpen();
+//        Boolean sessionOpenClose =  user.isOpen();
 
-        CurrentSessionResponseDto currentSession = sessionService.getArtistOpenSession(artistId, sessionOpenClose);
+//        CurrentSessionResponseDto currentSession = sessionService.getArtistOpenSession(artistId, sessionOpenClose);
+        CurrentSessionResponseDto currentSession = sessionService.getArtistSessionStatus(artistId);
 
         if (currentSession == null) {
             return new ResponseResult<>(ResponseCode.SUCCESS, "오픈된 세션이 없습니다.", null);

--- a/src/main/java/com/sing4u/kr/session/repository/SessionRepository.java
+++ b/src/main/java/com/sing4u/kr/session/repository/SessionRepository.java
@@ -8,6 +8,7 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
+import java.nio.channels.FileChannel;
 import java.util.List;
 import java.util.Optional;
 
@@ -24,4 +25,6 @@ public interface SessionRepository extends JpaRepository<Session, Long> {
     List<Session> findAllWithSongRequestsByArtist(@Param("artistId") Long artistId);
 
     Optional<Session> findByArtistIdAndStatus(Long artistId, SessionStatus status);
+
+    Optional<Session> findTopByArtistIdOrderByCreatedAtDesc(Long artistId);
 }

--- a/src/main/java/com/sing4u/kr/session/service/SessionService.java
+++ b/src/main/java/com/sing4u/kr/session/service/SessionService.java
@@ -68,15 +68,25 @@ public class SessionService {
         return SessionResponseDto.from(session);
     }
 
-    public CurrentSessionResponseDto getArtistOpenSession(Long artistId, Boolean sessionOpenClose) {
+//    public CurrentSessionResponseDto getArtistOpenSession(Long artistId, Boolean sessionOpenClose) {
+//        userRepository.findByIdAndUserTypeAndDeletedAtIsNull(artistId, UserType.ARTIST)
+//                .orElseThrow(() -> new ApiException(ExceptionCode.NOT_FOUND, "아티스트를 찾을 수 없습니다. ID: " + artistId));
+//
+//        SessionStatus status = Boolean.TRUE.equals(sessionOpenClose) ? SessionStatus.OPEN : SessionStatus.CLOSE;
+//
+//        return sessionRepository.findByArtistIdAndStatus(artistId, status)
+//                .map(CurrentSessionResponseDto::from)
+//                .orElse(null);
+//    }
+
+    public CurrentSessionResponseDto getArtistSessionStatus(Long artistId) {
+        // 아티스트 존재 확인
         userRepository.findByIdAndUserTypeAndDeletedAtIsNull(artistId, UserType.ARTIST)
                 .orElseThrow(() -> new ApiException(ExceptionCode.NOT_FOUND, "아티스트를 찾을 수 없습니다. ID: " + artistId));
 
-        SessionStatus status = Boolean.TRUE.equals(sessionOpenClose) ? SessionStatus.OPEN : SessionStatus.CLOSE;
-
-        return sessionRepository.findByArtistIdAndStatus(artistId, status)
+        // 세션 상태 조회 (OPEN이든 CLOSE든 가장 최신 세션 가져오기)
+        return sessionRepository.findTopByArtistIdOrderByCreatedAtDesc(artistId)
                 .map(CurrentSessionResponseDto::from)
                 .orElse(null);
     }
-
 }


### PR DESCRIPTION

## 문제 원인

- 기존 세션 조회 API(getArtistCurrentOpenSession)가 User.isOpen 플래그에 의존
- closeSession() 직후 DB 상태(CLOSE)와 불일치 → 500 에러 발생

--- 

## 개선 내용

- User.isOpen 의존 제거
- DB 기준 최신 세션 상태 조회(findTopByArtistIdOrderByCreatedAtDesc)로 변경
- closeSession()는 그대로 유지 (세션 상태 + closedAt 업데이트)