### PR TITLE
fix: 무한스크롤 중복/루프 유발하던 RAND() 제거 및 안정 랜덤 정렬 적용

### DIFF
--- a/src/main/java/com/sing4u/kr/home/controller/HomeController.java
+++ b/src/main/java/com/sing4u/kr/home/controller/HomeController.java
@@ -4,6 +4,7 @@ import com.sing4u.kr.common.dto.ResponseResult;
 import com.sing4u.kr.common.enums.ResponseCode;
 import com.sing4u.kr.common.response.PagingResponse;
 import com.sing4u.kr.home.dto.request.HomeRequest;
+import com.sing4u.kr.home.dto.response.HomeResponse;
 import com.sing4u.kr.user.dto.response.UserListResponse;
 import com.sing4u.kr.user.service.UserService;
 import jakarta.validation.Valid;
@@ -11,6 +12,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
+import java.util.UUID;
 
 @RestController
 @RequestMapping("/api/v1/home")
@@ -20,18 +22,24 @@ public class HomeController {
     private final UserService userService;
 
     @GetMapping
-    public ResponseResult<PagingResponse<UserListResponse>> getArtists(
+    public ResponseResult<HomeResponse> getArtists(
             @RequestParam int page,
             @RequestParam int pageSize,
-            @RequestParam(required = false) String keyword
+            @RequestParam(required = false) String keyword,
+            @RequestParam(required=false) String seed
     ) {
+        if (seed == null || seed.isBlank()) seed = UUID.randomUUID().toString();
+
         HomeRequest request = HomeRequest.builder()
                 .page(page)
                 .pageSize(pageSize)
                 .keyword(keyword)
+                .seed(seed)
                 .build();
 
-        PagingResponse<UserListResponse> response = userService.getArtistList(request);
+        PagingResponse<UserListResponse> paging = userService.getArtistList(request);
+        HomeResponse response = new HomeResponse(seed, paging);
+
         return new ResponseResult<>(ResponseCode.SUCCESS, response);
     }
 }

--- a/src/main/java/com/sing4u/kr/home/dto/request/HomeRequest.java
+++ b/src/main/java/com/sing4u/kr/home/dto/request/HomeRequest.java
@@ -10,6 +10,7 @@ import lombok.*;
 public class HomeRequest {
     private String keyword;
     private int page;
+    private String seed;
 
     @Builder.Default
     private int pageSize = 12;

--- a/src/main/java/com/sing4u/kr/home/dto/response/HomeResponse.java
+++ b/src/main/java/com/sing4u/kr/home/dto/response/HomeResponse.java
@@ -1,0 +1,8 @@
+package com.sing4u.kr.home.dto.response;
+
+import com.sing4u.kr.common.response.PagingResponse;
+import com.sing4u.kr.user.dto.response.UserListResponse;
+import lombok.*;
+
+public record HomeResponse(String seed, PagingResponse<UserListResponse> page) {
+}

--- a/src/main/java/com/sing4u/kr/user/repository/UserCustomRepository.java
+++ b/src/main/java/com/sing4u/kr/user/repository/UserCustomRepository.java
@@ -7,6 +7,6 @@ import org.springframework.data.domain.Slice;
 import java.util.List;
 
 public interface UserCustomRepository {
-    Slice<User> findArtistsWithKeywordAndRandomOrder(String keyword, Pageable pageable);
+    Slice<User> findArtistsWithKeywordAndRandomOrder(String keyword, String seed, Pageable pageable);
 }
 

--- a/src/main/java/com/sing4u/kr/user/repository/impl/UserCustomRepositoryImpl.java
+++ b/src/main/java/com/sing4u/kr/user/repository/impl/UserCustomRepositoryImpl.java
@@ -1,6 +1,8 @@
 package com.sing4u.kr.user.repository.impl;
 
 import com.querydsl.core.BooleanBuilder;
+import com.querydsl.core.types.Order;
+import com.querydsl.core.types.OrderSpecifier;
 import com.querydsl.core.types.dsl.Expressions;
 import com.querydsl.core.types.dsl.NumberTemplate;
 import com.querydsl.jpa.impl.JPAQueryFactory;
@@ -21,7 +23,7 @@ public class UserCustomRepositoryImpl implements UserCustomRepository {
     private final JPAQueryFactory queryFactory;
 
     @Override
-    public Slice<User> findArtistsWithKeywordAndRandomOrder(String keyword, Pageable pageable) {
+    public Slice<User> findArtistsWithKeywordAndRandomOrder(String keyword, String seed, Pageable pageable) {
         QUser user = QUser.user;
 
         BooleanBuilder condition = new BooleanBuilder()
@@ -31,12 +33,14 @@ public class UserCustomRepositoryImpl implements UserCustomRepository {
             condition.and(user.nickname.containsIgnoreCase(keyword));
         }
 
-        NumberTemplate<Double> rand = Expressions.numberTemplate(Double.class, "RAND()");
+        OrderSpecifier<String> stableRand =
+                new OrderSpecifier<>(Order.ASC,
+                        Expressions.stringTemplate("MD5(CONCAT({0}, '-', {1}))", seed, user.id));
 
         List<User> result = queryFactory
                 .selectFrom(user)
                 .where(condition)
-                .orderBy(user.isOpen.desc(), rand.asc())
+                .orderBy(user.isOpen.desc(), stableRand, user.id.asc())
                 .offset(pageable.getOffset())
                 .limit(pageable.getPageSize() + 1)
                 .fetch();

--- a/src/main/java/com/sing4u/kr/user/service/UserService.java
+++ b/src/main/java/com/sing4u/kr/user/service/UserService.java
@@ -51,7 +51,7 @@ public class UserService {
     @Transactional(readOnly = true)
     public PagingResponse<UserListResponse> getArtistList(HomeRequest request) {
         Pageable pageable = PageRequest.of(request.getPage(), request.getPageSize());
-        Slice<User> userSlice = userRepository.findArtistsWithKeywordAndRandomOrder(request.getKeyword(), pageable);
+        Slice<User> userSlice = userRepository.findArtistsWithKeywordAndRandomOrder(request.getKeyword(), request.getSeed(), pageable);
 
         Slice<UserListResponse> responseSlice = userSlice.map(UserListResponse::from);
         return PagingResponse.of(responseSlice);


### PR DESCRIPTION
### 배경
홈 아티스트 리스트가 `ORDER BY RAND()`로 정렬되어, 무한스크롤에서 페이지 간 **순서가 계속 바뀌고** **중복/루프**가 발생하는 문제

## 핵심 변경
1) 정렬 전략 변경 (버그 수정)
   - RAND() 제거 → **안정 랜덤**(seed 기반) 적용
   - 정렬식: **isOpen DESC → md5(CONCAT(seed,'-', id)) ASC → id ASC**
   - 목적: 동일 seed에서는 **순서 고정**, isOpen 우선 노출 유지

2) 리포지토리 시그니처 변경
   - `findArtistsWithKeywordAndRandomOrder(String keyword, String seed, Pageable pageable)`
   - seed를 전달받아 결정론적 정렬을 수행

3) 컨트롤러/서비스 파이프라인 수정
   - `/api/v1/home`에서 seed를 **생성하여 응답에 포함**(최초 요청 seed 미지정 시)
   - 이후 요청은 클라이언트가 받은 **seed를 그대로 에코**하여 동일 순서 유지

4) 응답 스키마 확장
   - `PagingResponse<T>` 그대로 유지하면서,
   - **래퍼 DTO `HomeResponse`** 추가: `{ seed, page: PagingResponse<UserListResponse> }`


### 테스트 시나리오
- [ ] 동일 seed로 page 0→1→2 요청 시 **순서가 변하지 않음**
- [ ] 다른 seed로 요청 시 순서가 달라짐(랜덤 효과 확인)
- [ ] isOpen=true 항목이 항상 상단에 우선 노출
- [ ] keyword가 달라지면 결과/순서가 seed 내에서 일관
- [ ] 응답 스키마 변경에 따른 FE 연동 확인

### 기타
- 데이터량 커지면 커서 기반 전환/스냅샷 캐시 고려 예정(QA 후)

