### PR TITLE
feat-퍼블릭아이디로 활동 플랫폼 가져오기

### DIFF
--- a/src/main/java/com/sing4u/kr/user/controller/UserPlatformController.java
+++ b/src/main/java/com/sing4u/kr/user/controller/UserPlatformController.java
@@ -30,4 +30,11 @@ public class UserPlatformController {
         Long userId = SecurityContextUtils.getAccountId();
         return new ResponseResult<>(ResponseCode.SUCCESS, userService.updateActivityPlatform(userId, request));
     }
+
+    @Operation(summary = "userPublicId로 특정 사용자 활동 플랫폼 조회", description = "userPublicId 특정 사용자의 활동 플랫폼 조회")
+    @GetMapping("/{userPublicId}/activity-platform")
+    public ResponseResult<UserActivityPlatformResponse> getActivityPlatformByPublicId(@PathVariable String publicId) {
+        Long userId = userService.getUserIdByPublicId(publicId);
+        return new ResponseResult<>(ResponseCode.SUCCESS, userService.getActivityPlatform(userId));
+    }
 }


### PR DESCRIPTION
프론트에서 userPublicId 기반으로 활동 플랫폼 조회가 필요하여,

---
- `/{userPublicId}/activity-platform` API를 추가
- `userId` 매핑 후 플랫폼 정보를 반환하도록 구현 개발.