### PR TITLE
fix: 이메일 중복 가입 예외처리 및 탈퇴 시 열린 세션 정리

### DIFF
--- a/src/main/java/com/sing4u/kr/session/controller/SessionController.java
+++ b/src/main/java/com/sing4u/kr/session/controller/SessionController.java
@@ -6,6 +6,7 @@ import com.sing4u.kr.common.exception.ApiException;
 import com.sing4u.kr.common.exception.ExceptionCode;
 import com.sing4u.kr.session.dto.response.CurrentSessionResponseDto;
 import com.sing4u.kr.session.dto.response.SessionResponseDto;
+import com.sing4u.kr.session.enums.SessionStatus;
 import com.sing4u.kr.session.service.SessionService;
 import com.sing4u.kr.user.entity.User;
 import com.sing4u.kr.user.repository.UserRepository;
@@ -15,6 +16,7 @@ import io.swagger.v3.oas.annotations.Parameter;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.bind.annotation.*;
 
 @RestController

--- a/src/main/java/com/sing4u/kr/session/repository/SessionRepository.java
+++ b/src/main/java/com/sing4u/kr/session/repository/SessionRepository.java
@@ -27,4 +27,6 @@ public interface SessionRepository extends JpaRepository<Session, Long> {
     Optional<Session> findByArtistIdAndStatus(Long artistId, SessionStatus status);
 
     Optional<Session> findTopByArtistIdOrderByStartedAtDesc(Long artistId);
+
+    Iterable<Session> findAllByArtistIdAndStatus(Long artistId, SessionStatus sessionStatus);
 }

--- a/src/main/java/com/sing4u/kr/session/service/SessionService.java
+++ b/src/main/java/com/sing4u/kr/session/service/SessionService.java
@@ -89,4 +89,13 @@ public class SessionService {
                 .map(CurrentSessionResponseDto::from)
                 .orElse(null);
     }
+
+    @Transactional
+    public void closeAllOpenByArtist(Long artistId) {
+        sessionRepository.findAllByArtistIdAndStatus(artistId, SessionStatus.OPEN)
+                .forEach(Session::close);
+        userRepository.findByIdAndUserTypeAndDeletedAtIsNull(artistId, UserType.ARTIST)
+                .ifPresent(artist -> artist.updateIsOpen(false));
+    }
+
 }

--- a/src/main/java/com/sing4u/kr/user/service/UserService.java
+++ b/src/main/java/com/sing4u/kr/user/service/UserService.java
@@ -7,6 +7,7 @@ import com.sing4u.kr.common.enums.ResponseCode;
 import com.sing4u.kr.common.exception.Exception400;
 import com.sing4u.kr.common.response.PagingResponse;
 import com.sing4u.kr.home.dto.request.HomeRequest;
+import com.sing4u.kr.session.service.SessionService;
 import com.sing4u.kr.user.dto.request.*;
 import com.sing4u.kr.user.dto.response.*;
 import com.sing4u.kr.user.entity.User;
@@ -42,6 +43,7 @@ public class UserService {
     private final UserActivityPlatformRepository userActivityPlatformRepository;
     private final PasswordEncoder passwordEncoder;
     private final S3Service s3Service;
+    private final SessionService sessionService;
 
 //    @Cacheable(
 //            value = "homeArtists",
@@ -172,6 +174,12 @@ public class UserService {
     @Transactional
     public void deleteUser(Long id) {
         User user = getEntityOrThrow(id);
+
+        // 아티스트라면 열린 세션 정리
+        if (user.getUserType() == UserType.ARTIST) {
+            sessionService.closeAllOpenByArtist(user.getId());
+        }
+
         user.delete();
         userRepository.save(user);
     }

--- a/src/main/java/com/sing4u/kr/user/service/UserService.java
+++ b/src/main/java/com/sing4u/kr/user/service/UserService.java
@@ -64,7 +64,12 @@ public class UserService {
 //    )
     @Transactional
     public UserCreateResponse createUser(UserCreateRequest request) {
-        User user = User.of(request.getNickname(), request.getEmail(), passwordEncoder.encode(request.getPassword()), request.getUserType());
+        String email = request.getEmail();
+        if (userRepository.existsByEmailIgnoreCase(email)) {
+            throw new Exception409(ResponseCode.ERROR_ALREADY_EXIST_USER, "이미 사용 중인 이메일입니다.");
+        }
+
+        User user = User.of(request.getNickname(), email, passwordEncoder.encode(request.getPassword()), request.getUserType());
         return UserCreateResponse.from(userRepository.save(user));
     }
 


### PR DESCRIPTION

# feat(user): 이메일 중복 가입 예외처리 및 탈퇴 시 열린 세션 정리

## 1) 배경 / 목적

* **QA 피드백**

  * 회원가입 시 **중복 이메일**로도 가입이 진행되는 문제.
  * **회원탈퇴** 시 해당 사용자가 **열린 아티스트 세션**을 보유하고 있으면 오류 발생.
* **개선 목표**

  * 중복 이메일에 대한 **사전 검증 및 명확한 예외 반환**.
  * 탈퇴 로직에서 **열린 세션을 선 정리**하여 안정적으로 탈퇴 처리.

---

## 2) 주요 변경 사항 (Summary)

1. **회원가입: 중복 이메일 예외 처리 추가**

2. **회원탈퇴: 열린 세션 정리 후 탈퇴**

---

## 3) 상세 변경 (Diff 개요)

* **UserService**

  * `createUser` : 이메일 중복 여부 검사 및 `Exception409` 발생 추가
  * `deleteUser` : 탈퇴 전 `sessionService.closeAllOpenByArtist(artistId)` 호출 추가, 이후 `user.delete()` 진행
* **SessionService**

  * `closeAllOpenByArtist(Long artistId)` 추가

    * `findAllByArtistIdAndStatus(artistId, OPEN)` → `Session::close`
    * 아티스트 상태 동기화(`artist.updateIsOpen(false)`) 포함
* **SessionRepository**

  * `findAllByArtistIdAndStatus(Long artistId, SessionStatus sessionStatus)` 추가


