### PR TITLE
feat: 신청곡 좋아요 및 좋아요 취소 API 추가

### DIFF
--- a/src/main/java/com/sing4u/kr/session/controller/SessionController.java
+++ b/src/main/java/com/sing4u/kr/session/controller/SessionController.java
@@ -6,6 +6,7 @@ import com.sing4u.kr.common.exception.ApiException;
 import com.sing4u.kr.common.exception.ExceptionCode;
 import com.sing4u.kr.session.dto.response.CurrentSessionResponseDto;
 import com.sing4u.kr.session.dto.response.SessionResponseDto;
+import com.sing4u.kr.session.enums.SessionStatus;
 import com.sing4u.kr.session.service.SessionService;
 import com.sing4u.kr.user.entity.User;
 import com.sing4u.kr.user.repository.UserRepository;
@@ -15,6 +16,7 @@ import io.swagger.v3.oas.annotations.Parameter;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.bind.annotation.*;
 
 @RestController

--- a/src/main/java/com/sing4u/kr/session/repository/SessionRepository.java
+++ b/src/main/java/com/sing4u/kr/session/repository/SessionRepository.java
@@ -27,4 +27,6 @@ public interface SessionRepository extends JpaRepository<Session, Long> {
     Optional<Session> findByArtistIdAndStatus(Long artistId, SessionStatus status);
 
     Optional<Session> findTopByArtistIdOrderByStartedAtDesc(Long artistId);
+
+    Iterable<Session> findAllByArtistIdAndStatus(Long artistId, SessionStatus sessionStatus);
 }

--- a/src/main/java/com/sing4u/kr/session/service/SessionService.java
+++ b/src/main/java/com/sing4u/kr/session/service/SessionService.java
@@ -89,4 +89,13 @@ public class SessionService {
                 .map(CurrentSessionResponseDto::from)
                 .orElse(null);
     }
+
+    @Transactional
+    public void closeAllOpenByArtist(Long artistId) {
+        sessionRepository.findAllByArtistIdAndStatus(artistId, SessionStatus.OPEN)
+                .forEach(Session::close);
+        userRepository.findByIdAndUserTypeAndDeletedAtIsNull(artistId, UserType.ARTIST)
+                .ifPresent(artist -> artist.updateIsOpen(false));
+    }
+
 }

--- a/src/main/java/com/sing4u/kr/songRequest/entity/SongRequest.java
+++ b/src/main/java/com/sing4u/kr/songRequest/entity/SongRequest.java
@@ -43,6 +43,19 @@ public class SongRequest {
     @Column(name = "requested_at", nullable = false, updatable = false, columnDefinition = "datetime")
     private LocalDateTime requestedAt;
 
+    @Builder.Default
+    @Column(nullable=false)
+    private long likeCount = 0L;
+
+    public void increaseLikeCount() {
+        this.likeCount++;
+    }
+
+    public void decreaseLikeCount() {
+        if (this.likeCount > 0)
+            this.likeCount--;
+    }
+
 }
 
 

--- a/src/main/java/com/sing4u/kr/songRequest/like/controller/SongRequestLikeController.java
+++ b/src/main/java/com/sing4u/kr/songRequest/like/controller/SongRequestLikeController.java
@@ -1,0 +1,130 @@
+package com.sing4u.kr.songRequest.like.controller;
+
+import com.sing4u.kr.common.auth.LoginUserId;
+import com.sing4u.kr.common.dto.ResponseResult;
+import com.sing4u.kr.songRequest.like.dto.response.SongRequestLikeResponse;
+import com.sing4u.kr.songRequest.like.service.SongRequestLikeService;
+import com.sing4u.kr.user.entity.User;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/v1/song-requests/{requestId}/likes")
+@RequiredArgsConstructor
+public class SongRequestLikeController {
+    private final SongRequestLikeService service;
+
+    @Operation(
+            summary = "좋아요 추가",
+            description = """
+    해당 신청곡에 좋아요를 누릅니다(멱등).
+    이미 눌린 상태여도 에러 없이 성공으로 처리하며,
+    최신 상태(liked=true, likeCount)를 반환합니다.
+    """
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "성공",
+                    content = @Content(mediaType = "application/json",
+                            examples = @ExampleObject(value = """
+            {
+              "code": "0001",
+              "message": "성공",
+              "data": { "liked": true, "likeCount": 53 }
+            }
+            """))),
+            @ApiResponse(responseCode = "401", description = "인증 필요",
+                    content = @Content(mediaType = "application/json",
+                            examples = @ExampleObject(value = """
+            { "code": "UNAUTHORIZED", "message": "로그인이 필요합니다." }
+            """))),
+            @ApiResponse(responseCode = "404", description = "신청곡 없음",
+                    content = @Content(mediaType = "application/json",
+                            examples = @ExampleObject(value = """
+            { "code": "NOT_FOUND", "message": "신청곡을 찾을 수 없습니다." }
+            """)))
+    })
+    @PostMapping
+    public ResponseResult<SongRequestLikeResponse> like(
+            @PathVariable Long requestId,
+            @LoginUserId Long userId) {
+        return new ResponseResult<>(service.like(requestId, userId));
+    }
+
+    @Operation(
+            summary = "좋아요 취소",
+            description = """
+    해당 신청곡의 좋아요를 취소합니다(멱등).
+    이미 좋아요가 없는 상태여도 에러 없이 성공으로 처리하며,
+    최신 상태(liked=false, likeCount)를 반환합니다.
+    """
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "성공",
+                    content = @Content(mediaType = "application/json",
+                            examples = @ExampleObject(value = """
+            {
+              "code": "0001",
+              "message": "성공",
+              "data": { "liked": false, "likeCount": 52 }
+            }
+            """))),
+            @ApiResponse(responseCode = "401", description = "인증 필요",
+                    content = @Content(mediaType = "application/json",
+                            examples = @ExampleObject(value = """
+            { "code": "UNAUTHORIZED", "message": "로그인이 필요합니다." }
+            """))),
+            @ApiResponse(responseCode = "404", description = "신청곡 없음",
+                    content = @Content(mediaType = "application/json",
+                            examples = @ExampleObject(value = """
+            { "code": "NOT_FOUND", "message": "신청곡을 찾을 수 없습니다." }
+            """)))
+    })
+    @DeleteMapping
+    public ResponseResult<SongRequestLikeResponse> unlike(
+            @PathVariable Long requestId,
+            @LoginUserId Long userId) {
+        return new ResponseResult<>(service.unlike(requestId, userId));
+    }
+
+    @Operation(
+            summary = "좋아요 상태 조회",
+            description = """
+    현재 로그인한 사용자가 해당 신청곡에 좋아요를 눌렀는지 여부와
+    현재 좋아요 수를 조회합니다.
+    """
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "성공",
+                    content = @Content(mediaType = "application/json",
+                            examples = @ExampleObject(value = """
+            {
+              "code": "0001",
+              "message": "성공",
+              "data": { "liked": true, "likeCount": 52 }
+            }
+            """))),
+            @ApiResponse(responseCode = "401", description = "인증 필요",
+                    content = @Content(mediaType = "application/json",
+                            examples = @ExampleObject(value = """
+            { "code": "UNAUTHORIZED", "message": "로그인이 필요합니다." }
+            """))),
+            @ApiResponse(responseCode = "404", description = "신청곡 없음",
+                    content = @Content(mediaType = "application/json",
+                            examples = @ExampleObject(value = """
+            { "code": "NOT_FOUND", "message": "신청곡을 찾을 수 없습니다." }
+            """)))
+    })
+    @GetMapping
+    public ResponseResult<SongRequestLikeResponse> status(
+            @PathVariable Long requestId,
+            @LoginUserId Long userId) {
+        return new ResponseResult<>(service.getStatus(requestId, userId));
+    }
+}

--- a/src/main/java/com/sing4u/kr/songRequest/like/controller/SongRequestLikeController.java
+++ b/src/main/java/com/sing4u/kr/songRequest/like/controller/SongRequestLikeController.java
@@ -16,7 +16,7 @@ import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
-@RequestMapping("/api/v1/song-requests/{requestId}/likes")
+@RequestMapping("/api/v1/song-requests/{songRequestId}/likes")
 @RequiredArgsConstructor
 public class SongRequestLikeController {
     private final SongRequestLikeService service;

--- a/src/main/java/com/sing4u/kr/songRequest/like/dto/response/SongRequestLikeResponse.java
+++ b/src/main/java/com/sing4u/kr/songRequest/like/dto/response/SongRequestLikeResponse.java
@@ -1,0 +1,11 @@
+package com.sing4u.kr.songRequest.like.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class SongRequestLikeResponse {
+    private final boolean liked;
+    private final long likeCount;
+}

--- a/src/main/java/com/sing4u/kr/songRequest/like/entity/SongRequestLike.java
+++ b/src/main/java/com/sing4u/kr/songRequest/like/entity/SongRequestLike.java
@@ -1,0 +1,39 @@
+package com.sing4u.kr.songRequest.like.entity;
+
+import com.sing4u.kr.songRequest.entity.SongRequest;
+import com.sing4u.kr.user.entity.User;
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@Builder
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "song_request_like",
+        uniqueConstraints = @UniqueConstraint(
+                name = "uk_song_request_like_user_req",
+                columnNames = {"user_id","song_request_id"}
+        )
+)
+public class SongRequestLike {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional=false)
+    @JoinColumn(name="user_id", nullable=false)
+    private User user;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional=false)
+    @JoinColumn(name="song_request_id", nullable=false)
+    private SongRequest songRequest;
+
+    @Column(nullable=false, updatable=false)
+    private LocalDateTime createdAt;
+
+    @PrePersist
+    void onCreate() { this.createdAt = LocalDateTime.now(); }
+}

--- a/src/main/java/com/sing4u/kr/songRequest/like/repository/SongRequestLikeRepository.java
+++ b/src/main/java/com/sing4u/kr/songRequest/like/repository/SongRequestLikeRepository.java
@@ -1,0 +1,16 @@
+package com.sing4u.kr.songRequest.like.repository;
+
+import com.sing4u.kr.songRequest.like.entity.SongRequestLike;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+public interface SongRequestLikeRepository extends JpaRepository<SongRequestLike, Long> {
+
+    boolean existsByUserIdAndSongRequestId(Long userId, Long songRequestId);
+
+    Optional<SongRequestLike> findByUserIdAndSongRequestId(Long userId, Long songRequestId);
+
+}

--- a/src/main/java/com/sing4u/kr/songRequest/like/service/SongRequestLikeService.java
+++ b/src/main/java/com/sing4u/kr/songRequest/like/service/SongRequestLikeService.java
@@ -1,0 +1,91 @@
+package com.sing4u.kr.songRequest.like.service;
+
+import com.sing4u.kr.common.exception.ApiException;
+import com.sing4u.kr.common.exception.Exception400;
+import com.sing4u.kr.common.exception.ExceptionCode;
+import com.sing4u.kr.songRequest.entity.SongRequest;
+import com.sing4u.kr.songRequest.like.dto.response.SongRequestLikeResponse;
+import com.sing4u.kr.songRequest.like.entity.SongRequestLike;
+import com.sing4u.kr.songRequest.like.repository.SongRequestLikeRepository;
+import com.sing4u.kr.songRequest.repository.SongRequestRepository;
+import com.sing4u.kr.user.entity.User;
+import com.sing4u.kr.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class SongRequestLikeService {
+    private final SongRequestRepository songRequestRepository;
+    private final SongRequestLikeRepository likeRepository;
+    private final UserRepository userRepository;
+
+    private SongRequest getRequestOrThrow(Long requestId) {
+        return songRequestRepository.findById(requestId)
+                .orElseThrow(() -> new ApiException(ExceptionCode.NOT_FOUND, "신청곡을 찾을 수 없습니다."));
+    }
+
+    @Transactional
+    public SongRequestLikeResponse like(Long requestId, Long userId) {
+        SongRequest req = getRequestOrThrow(requestId);
+
+        if (likeRepository.existsByUserIdAndSongRequestId(userId, requestId)) {
+            // 이미 눌렀다면 그대로 반환
+            long count = currentCount(req);
+            return new SongRequestLikeResponse(true, count);
+        }
+
+        try {
+            // User 프록시만 생성해서 넣기
+            User userRef = userRepository.getReferenceById(userId);
+
+            likeRepository.save(
+                    SongRequestLike.builder()
+                            .user(userRef)
+                            .songRequest(req)
+                            .build()
+            );
+        } catch (DataIntegrityViolationException e) {
+            // UNIQUE 제약 위반일 때만 무시 (다른 위반이면 다시 던짐)
+            if (e.getMessage() != null && e.getMessage().contains("song_request_like_unique")) {
+                log.debug("Duplicate like ignored (UNIQUE constraint). userId={}, requestId={}", userId, requestId);
+            } else {
+                throw e; // 예상 외 제약 위반은 그대로 예외로 던짐
+            }
+        }
+
+        req.increaseLikeCount();
+
+        return new SongRequestLikeResponse(true, currentCount(req));
+    }
+
+    @Transactional
+    public SongRequestLikeResponse unlike(Long requestId, Long userId) {
+        SongRequest req = getRequestOrThrow(requestId);
+
+        likeRepository.findByUserIdAndSongRequestId(userId, requestId)
+                .ifPresent(like -> {
+                    likeRepository.delete(like);
+                    req.decreaseLikeCount(); // 눌려 있었을 때만 감소
+                });
+
+        // 눌려 있지 않아도 예외 없이 성공 처리, 현재 상태만 반환
+        return new SongRequestLikeResponse(false, currentCount(req));
+    }
+
+    @Transactional
+    public SongRequestLikeResponse getStatus(Long requestId, Long userId) {
+        SongRequest req = getRequestOrThrow(requestId);
+        boolean liked = likeRepository.existsByUserIdAndSongRequestId(userId, requestId);
+        long count = currentCount(req);
+        return new SongRequestLikeResponse(liked, count);
+    }
+
+    private long currentCount(SongRequest req) {
+        return req.getLikeCount();
+    }
+}

--- a/src/main/java/com/sing4u/kr/user/service/UserService.java
+++ b/src/main/java/com/sing4u/kr/user/service/UserService.java
@@ -7,6 +7,7 @@ import com.sing4u.kr.common.enums.ResponseCode;
 import com.sing4u.kr.common.exception.Exception400;
 import com.sing4u.kr.common.response.PagingResponse;
 import com.sing4u.kr.home.dto.request.HomeRequest;
+import com.sing4u.kr.session.service.SessionService;
 import com.sing4u.kr.user.dto.request.*;
 import com.sing4u.kr.user.dto.response.*;
 import com.sing4u.kr.user.entity.User;
@@ -42,6 +43,7 @@ public class UserService {
     private final UserActivityPlatformRepository userActivityPlatformRepository;
     private final PasswordEncoder passwordEncoder;
     private final S3Service s3Service;
+    private final SessionService sessionService;
 
 //    @Cacheable(
 //            value = "homeArtists",
@@ -172,6 +174,12 @@ public class UserService {
     @Transactional
     public void deleteUser(Long id) {
         User user = getEntityOrThrow(id);
+
+        // 아티스트라면 열린 세션 정리
+        if (user.getUserType() == UserType.ARTIST) {
+            sessionService.closeAllOpenByArtist(user.getId());
+        }
+
         user.delete();
         userRepository.save(user);
     }

--- a/src/main/java/com/sing4u/kr/user/service/UserService.java
+++ b/src/main/java/com/sing4u/kr/user/service/UserService.java
@@ -64,7 +64,12 @@ public class UserService {
 //    )
     @Transactional
     public UserCreateResponse createUser(UserCreateRequest request) {
-        User user = User.of(request.getNickname(), request.getEmail(), passwordEncoder.encode(request.getPassword()), request.getUserType());
+        String email = request.getEmail();
+        if (userRepository.existsByEmailIgnoreCase(email)) {
+            throw new Exception409(ResponseCode.ERROR_ALREADY_EXIST_USER, "이미 사용 중인 이메일입니다.");
+        }
+
+        User user = User.of(request.getNickname(), email, passwordEncoder.encode(request.getPassword()), request.getUserType());
         return UserCreateResponse.from(userRepository.save(user));
     }
 


### PR DESCRIPTION

## 📄 개요 (Summary)
신청곡에 대한 **좋아요 / 좋아요 취소 / 좋아요 상태 조회** 기능 추가
사용자는 로그인 후 특정 신청곡에 좋아요를 누르거나 취소할 수 있으며,  
현재 자신이 좋아요를 눌렀는지 여부와 총 좋아요 수 조회 가능

---

## ✨ 주요 변경사항 (Changes)
- **`SongRequestLikeController` 추가**
  - `POST /api/v1/song-requests/{requestId}/likes` → 좋아요 등록  
  - `DELETE /api/v1/song-requests/{requestId}/likes` → 좋아요 취소  
  - `GET /api/v1/song-requests/{requestId}/likes` → 좋아요 상태 조회  

- **`SongRequestLikeService` 추가**
  - `like()`, `unlike()`, `getStatus()`, `currentCount()` 
  - 멱등 처리 적용 (이미 좋아요 누른 경우/취소된 경우에도 예외 없이 현재 상태 반환)  
  
- **`SongRequestLikeResponse` 추가**

- **`SongRequestLike` 추가**

- **`SongRequestLikeRepository` 추가**

- **`SongRequest`** 수정
  - `likeCount` 필드 추가
  - `increaseLikeCount()`, `decreaseLikeCount()` 메소드 추가  

