### PR TITLE
feat: 아티스트용 신청곡/세션 관련 API 추가

### DIFF
--- a/src/main/java/com/sing4u/kr/music/spotify/SpotifyMusicService.java
+++ b/src/main/java/com/sing4u/kr/music/spotify/SpotifyMusicService.java
@@ -87,6 +87,7 @@ public class SpotifyMusicService implements MusicInterface {
                     .title(track.getName())
                     .artistName(artistNames)
                     .platformName(PLATFORM_IDENTIFIER)
+                    .albumImageUrl(getCoverUrl(track))
                     .build();
         } catch (SpotifyWebApiException e) {
             logger.error("Spotify API 오류 (트랙 ID: {}): {}", platformTrackId, e.getMessage());

--- a/src/main/java/com/sing4u/kr/session/controller/SessionController.java
+++ b/src/main/java/com/sing4u/kr/session/controller/SessionController.java
@@ -24,6 +24,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.bind.annotation.*;
+import se.michaelthelin.spotify.model_objects.specification.Paging;
 
 @RestController
 @RequestMapping("/api/v1/artists")
@@ -81,7 +82,7 @@ public class SessionController {
     @GetMapping("/{artistPublicId}/sessions")
     @Operation(summary = "아티스트의 세션 목록 조회",
             description = "page/pageSize로 페이지네이션, 최신 순으로 정렬")
-    public ResponseEntity<PagingResponse<SessionResponseDto>> getSessions(
+    public ResponseResult<PagingResponse<SessionResponseDto>> getSessions(
             @Parameter(description = "세션 목록을 조회할 아티스트의 공개 ID", example = "user_public_id_1") @PathVariable String artistPublicId,
             @Parameter(description = "현재 페이지(0-base)") @RequestParam(defaultValue = "0") int page,
             @Parameter(description = "페이지 크기") @RequestParam(defaultValue = "10") int pageSize
@@ -95,7 +96,7 @@ public class SessionController {
                 .getSessionsByArtist(artistId, pageable)
                 .map(SessionResponseDto::from);
 
-        return ResponseEntity.ok(PagingResponse.of(dtoPage));
+        return new ResponseResult<>(ResponseCode.SUCCESS, PagingResponse.of(dtoPage));
     }
 
     @GetMapping("/{artistPublicId}/sessions/manage")
@@ -103,7 +104,7 @@ public class SessionController {
             summary = "세션 목록 조회(아티스트용)",
             description = "세션별 신청곡 수를 포함한 아티스트 관리용 세션 목록 조회"
     )
-    public ResponseEntity<PagingResponse<ArtistSessionResponseDto>> getArtistSessionsForManage(
+    public ResponseResult<PagingResponse<ArtistSessionResponseDto>> getArtistSessionsForManage(
             @Parameter(description = "아티스트 공개 ID", example = "user_public_id_1")
             @PathVariable String artistPublicId,
             @Parameter(description = "현재 페이지(0-base)")
@@ -118,7 +119,7 @@ public class SessionController {
         Page<ArtistSessionResponseDto> dtoPage =
                 sessionService.getArtistSessionsForManage(artistId, pageable);
 
-        return ResponseEntity.ok(PagingResponse.of(dtoPage));
+        return new ResponseResult<>(ResponseCode.SUCCESS, PagingResponse.of(dtoPage));
     }
 
 }

--- a/src/main/java/com/sing4u/kr/session/controller/SessionController.java
+++ b/src/main/java/com/sing4u/kr/session/controller/SessionController.java
@@ -5,6 +5,7 @@ import com.sing4u.kr.common.enums.ResponseCode;
 import com.sing4u.kr.common.exception.ApiException;
 import com.sing4u.kr.common.exception.ExceptionCode;
 import com.sing4u.kr.common.response.PagingResponse;
+import com.sing4u.kr.session.dto.response.ArtistSessionResponseDto;
 import com.sing4u.kr.session.dto.response.CurrentSessionResponseDto;
 import com.sing4u.kr.session.dto.response.SessionResponseDto;
 import com.sing4u.kr.session.enums.SessionStatus;
@@ -96,4 +97,28 @@ public class SessionController {
 
         return ResponseEntity.ok(PagingResponse.of(dtoPage));
     }
+
+    @GetMapping("/{artistPublicId}/sessions/manage")
+    @Operation(
+            summary = "세션 목록 조회(아티스트용)",
+            description = "세션별 신청곡 수를 포함한 아티스트 관리용 세션 목록 조회"
+    )
+    public ResponseEntity<PagingResponse<ArtistSessionResponseDto>> getArtistSessionsForManage(
+            @Parameter(description = "아티스트 공개 ID", example = "user_public_id_1")
+            @PathVariable String artistPublicId,
+            @Parameter(description = "현재 페이지(0-base)")
+            @RequestParam(defaultValue = "0") int page,
+            @Parameter(description = "페이지 크기")
+            @RequestParam(defaultValue = "10") int pageSize
+    ) {
+        Long artistId = userService.getUserIdByPublicId(artistPublicId);
+
+        var pageable = PageRequest.of(page, pageSize, Sort.by(Sort.Direction.DESC, "startedAt"));
+
+        Page<ArtistSessionResponseDto> dtoPage =
+                sessionService.getArtistSessionsForManage(artistId, pageable);
+
+        return ResponseEntity.ok(PagingResponse.of(dtoPage));
+    }
+
 }

--- a/src/main/java/com/sing4u/kr/session/dto/response/ArtistSessionResponseDto.java
+++ b/src/main/java/com/sing4u/kr/session/dto/response/ArtistSessionResponseDto.java
@@ -28,4 +28,12 @@ public class ArtistSessionResponseDto {
     @Schema(description = "세션 당 추천곡 수 합계", example = "128")
     private Long songRequestCount;
 
+    //JPQL용
+    public ArtistSessionResponseDto(Long sessionId, SessionStatus status, LocalDateTime startedAt, LocalDateTime closedAt, Long songRequestCount) {
+        this.sessionId = sessionId;
+        this.status = status;
+        this.startedAt = startedAt;
+        this.closedAt = closedAt;
+        this.songRequestCount = songRequestCount;
+    }
 }

--- a/src/main/java/com/sing4u/kr/session/dto/response/ArtistSessionResponseDto.java
+++ b/src/main/java/com/sing4u/kr/session/dto/response/ArtistSessionResponseDto.java
@@ -12,14 +12,11 @@ import java.time.LocalDateTime;
 @Getter
 @Builder
 @JsonInclude(JsonInclude.Include.NON_NULL)
-public class SessionResponseDto {
+public class ArtistSessionResponseDto {
     @Schema(description = "세션 ID", example = "1")
     private Long sessionId;
 
-    @Schema(description = "세션의 아티스트 ID", example = "user_public_id_1")
-    private String artistId;
-
-    @Schema(description = "세션 상태", example = "OPEN", implementation = SessionStatus.class)
+    @Schema(description = "세션 상태", example = "OPEN",implementation = SessionStatus.class)
     private SessionStatus status;
 
     @Schema(description = "세션 시작 시각", example = "2025-06-16T10:00:00")
@@ -28,13 +25,7 @@ public class SessionResponseDto {
     @Schema(description = "세션 종료 시각 (종료되지 않았으면 null)", example = "2025-06-16T12:00:00")
     private LocalDateTime closedAt;
 
-    public static SessionResponseDto from(Session session) {
-        return SessionResponseDto.builder()
-                .sessionId(session.getId())
-                .artistId(session.getArtist().getUserPublicId())
-                .status(session.getStatus())
-                .startedAt(session.getStartedAt())
-                .closedAt(session.getClosedAt())
-                .build();
-    }
+    @Schema(description = "세션 당 추천곡 수 합계", example = "128")
+    private Long songRequestCount;
+
 }

--- a/src/main/java/com/sing4u/kr/session/repository/SessionRepository.java
+++ b/src/main/java/com/sing4u/kr/session/repository/SessionRepository.java
@@ -1,5 +1,6 @@
 package com.sing4u.kr.session.repository;
 
+import com.sing4u.kr.session.dto.response.ArtistSessionResponseDto;
 import com.sing4u.kr.session.entity.Session;
 import com.sing4u.kr.session.enums.SessionStatus;
 import com.sing4u.kr.user.entity.User;
@@ -10,7 +11,6 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
-import java.nio.channels.FileChannel;
 import java.util.List;
 import java.util.Optional;
 
@@ -33,4 +33,20 @@ public interface SessionRepository extends JpaRepository<Session, Long> {
     Page<Session> findByArtistIdOrderByStartedAtDesc(Long artistId, Pageable pageable);
     
     Iterable<Session> findAllByArtistIdAndStatus(Long artistId, SessionStatus sessionStatus);
+
+    @Query("""
+        SELECT NEW com.sing4u.kr.session.dto.response.ArtistSessionResponseDto(
+            s.id,
+            s.status,
+            s.startedAt,
+            s.closedAt,
+            count(sr.id)
+        )
+        FROM Session s
+        LEFT JOIN SongRequest sr ON sr.session = s
+        WHERE s.artist.id = :artistId
+        GROUP BY s.id, s.status, s.startedAt, s.closedAt
+        ORDER BY s.startedAt desc
+    """)
+    Page<ArtistSessionResponseDto> findArtistSessionsForManage(@Param("artistId") Long artistId, Pageable pageable);
 }

--- a/src/main/java/com/sing4u/kr/session/service/SessionService.java
+++ b/src/main/java/com/sing4u/kr/session/service/SessionService.java
@@ -2,6 +2,7 @@ package com.sing4u.kr.session.service;
 
 import com.sing4u.kr.common.exception.ApiException;
 import com.sing4u.kr.common.exception.ExceptionCode;
+import com.sing4u.kr.session.dto.response.ArtistSessionResponseDto;
 import com.sing4u.kr.session.dto.response.CurrentSessionResponseDto;
 import com.sing4u.kr.session.dto.response.SessionResponseDto;
 import com.sing4u.kr.session.entity.Session;
@@ -108,4 +109,11 @@ public class SessionService {
                 .ifPresent(artist -> artist.updateIsOpen(false));
     }
 
+    public Page<ArtistSessionResponseDto> getArtistSessionsForManage(Long artistId, Pageable pageable) {
+        // 아티스트 존재 확인
+        userRepository.findByIdAndUserTypeAndDeletedAtIsNull(artistId, UserType.ARTIST)
+                .orElseThrow(() -> new ApiException(ExceptionCode.NOT_FOUND, "아티스트를 찾을 수 없습니다. ID: " + artistId));
+
+        return sessionRepository.findArtistSessionsForManage(artistId, pageable);
+    }
 }

--- a/src/main/java/com/sing4u/kr/songRequest/controller/SongRequestController.java
+++ b/src/main/java/com/sing4u/kr/songRequest/controller/SongRequestController.java
@@ -7,7 +7,6 @@ import com.sing4u.kr.songRequest.dto.SongRequestResponseDto;
 import com.sing4u.kr.songRequest.dto.response.ArtistSongRequestsResponse;
 import com.sing4u.kr.songRequest.enums.SortType;
 import com.sing4u.kr.songRequest.service.SongRequestService;
-import com.sing4u.kr.session.dto.SessionSongsDto;
 import com.sing4u.kr.user.service.UserService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -17,7 +16,6 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.*;
 
-import java.util.List;
 
 @RestController
 @RequestMapping("/api/v1/songRequests") // API 명세서 기준 Endpoint
@@ -46,7 +44,7 @@ public class SongRequestController {
 //    }
 
     @Operation(
-            summary = "아티스트 신청곡 조회",
+            summary = "아티스트 신청곡 조회(추천 리스트)",
             description = "아티스트에게 들어온 신청곡 목록을 조회합니다. sessionId, keyword, sort(LATEST/POPULAR), page, pageSize"
     )
     @GetMapping("/artists/{artistPublicId}")

--- a/src/main/java/com/sing4u/kr/songRequest/controller/SongRequestManageController.java
+++ b/src/main/java/com/sing4u/kr/songRequest/controller/SongRequestManageController.java
@@ -1,0 +1,34 @@
+package com.sing4u.kr.songRequest.controller;
+
+import com.sing4u.kr.songRequest.dto.response.SongRequestManageResponseDto;
+import com.sing4u.kr.songRequest.service.SongRequestService;
+import com.sing4u.kr.user.service.UserService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/v1")
+@RequiredArgsConstructor
+public class SongRequestManageController {
+
+    private final SongRequestService songRequestService;
+    private final UserService userService;
+
+    @Operation(
+            summary = "아티스트 신청곡 조회(추천 데이터)",
+            description = "추천 데이터 탭에서 신청곡을 집계(총 좋아요 수, 총 추천 수)하여 조회합니다. (keyword는 optional)"
+    )
+    @GetMapping("/artists/{artistPublicId}/song-requests/manage")
+    public SongRequestManageResponseDto getArtistSongRequestsManage(
+            @Parameter(description = "아티스트 공개 ID", example = "user_public_id_1")
+            @PathVariable String artistPublicId,
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "10") int pageSize,
+            @RequestParam(required = false) String keyword
+    ) {
+        Long artistId = userService.getUserIdByPublicId(artistPublicId);
+        return songRequestService.getArtistSongRequestsForManage(artistId, page, pageSize, keyword);
+    }
+}

--- a/src/main/java/com/sing4u/kr/songRequest/controller/SongRequestManageController.java
+++ b/src/main/java/com/sing4u/kr/songRequest/controller/SongRequestManageController.java
@@ -1,5 +1,8 @@
 package com.sing4u.kr.songRequest.controller;
 
+import com.sing4u.kr.common.dto.ResponseResult;
+import com.sing4u.kr.common.enums.ResponseCode;
+import com.sing4u.kr.songRequest.dto.response.ArtistSongRequestsResponse;
 import com.sing4u.kr.songRequest.dto.response.SongRequestManageResponseDto;
 import com.sing4u.kr.songRequest.service.SongRequestService;
 import com.sing4u.kr.user.service.UserService;
@@ -21,7 +24,7 @@ public class SongRequestManageController {
             description = "추천 데이터 탭에서 신청곡을 집계(총 좋아요 수, 총 추천 수)하여 조회합니다. (keyword는 optional)"
     )
     @GetMapping("/artists/{artistPublicId}/song-requests/manage")
-    public SongRequestManageResponseDto getArtistSongRequestsManage(
+    public ResponseResult<SongRequestManageResponseDto> getArtistSongRequestsManage(
             @Parameter(description = "아티스트 공개 ID", example = "user_public_id_1")
             @PathVariable String artistPublicId,
             @RequestParam(defaultValue = "0") int page,
@@ -29,6 +32,10 @@ public class SongRequestManageController {
             @RequestParam(required = false) String keyword
     ) {
         Long artistId = userService.getUserIdByPublicId(artistPublicId);
-        return songRequestService.getArtistSongRequestsForManage(artistId, page, pageSize, keyword);
+
+        SongRequestManageResponseDto result =
+                songRequestService.getArtistSongRequestsForManage(artistId, page, pageSize, keyword);
+
+        return new ResponseResult<>(ResponseCode.SUCCESS, result);
     }
 }

--- a/src/main/java/com/sing4u/kr/songRequest/dto/response/SongRequestManageItemDto.java
+++ b/src/main/java/com/sing4u/kr/songRequest/dto/response/SongRequestManageItemDto.java
@@ -1,0 +1,39 @@
+package com.sing4u.kr.songRequest.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class SongRequestManageItemDto {
+    @Schema(description = "신청곡 ID(대표값)", example = "1001")
+    private Long songRequestId;
+
+    @Schema(description = "곡 제목", example = "Blue Valentine")
+    private String songTitle;
+
+    @Schema(description = "가수명", example = "NMIXX")
+    private String singer;
+
+    @Schema(description = "해당 곡의 총 좋아요 수", example = "13")
+    private Long totalLikeCount;
+
+    @Schema(description = "앨범 커버 이미지 url", example = "https://i.scdn.co/image/ab67616d00")
+    private String albumImageUrl;
+
+    @Schema(description = "해당 곡의 총 추천(신청) 수", example = "4")
+    private Long totalRequestCount;
+
+    // JPQL 'SELECT NEW' 프로젝션을 위해 생성자 필요
+    public SongRequestManageItemDto(Long songRequestId, String songTitle, String singer, Long totalLikeCount, String albumImageUrl, Long totalRequestCount) {
+        this.songRequestId = songRequestId;
+        this.songTitle = songTitle;
+        this.singer = singer;
+        this.totalLikeCount = totalLikeCount;
+        this.albumImageUrl = albumImageUrl;
+        this.totalRequestCount = totalRequestCount;
+    }
+}

--- a/src/main/java/com/sing4u/kr/songRequest/dto/response/SongRequestManageResponseDto.java
+++ b/src/main/java/com/sing4u/kr/songRequest/dto/response/SongRequestManageResponseDto.java
@@ -1,0 +1,39 @@
+package com.sing4u.kr.songRequest.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+import lombok.Getter;
+import org.springframework.data.domain.Page;
+
+import java.util.List;
+
+@Getter
+@Builder
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class SongRequestManageResponseDto {
+    @Schema(description = "신청곡 리스트")
+    private List<SongRequestManageItemDto> songs;
+
+    @Schema(description = "다음 페이지 존재 여부", example = "true")
+    private boolean hasNext;
+
+    @Schema(description = "현재 페이지 인덱스(0-base)", example = "0")
+    private int page;
+
+    @Schema(description = "페이지 크기", example = "10")
+    private int pageSize;
+
+    @Schema(description = "전체 데이터(신청곡 수)", example = "37")
+    private long totalElements;
+
+    public static SongRequestManageResponseDto of(Page<SongRequestManageItemDto> pageResult) {
+        return SongRequestManageResponseDto.builder()
+                .songs(pageResult.getContent())
+                .hasNext(pageResult.hasNext())
+                .page(pageResult.getNumber())
+                .pageSize(pageResult.getSize())
+                .totalElements(pageResult.getTotalElements())
+                .build();
+    }
+}

--- a/src/main/java/com/sing4u/kr/songRequest/repository/SongRequestRepository.java
+++ b/src/main/java/com/sing4u/kr/songRequest/repository/SongRequestRepository.java
@@ -18,7 +18,7 @@ public interface SongRequestRepository extends JpaRepository<SongRequest, Long> 
     // TODO: songTitle/songArtistName 표기 차이(직접 입력한 곡과 스포티파이 검색 곡 차이)로 동일 곡이 분리 집계될 수 있을 것 같아서 해결방안 생각해야 함
     @Query(
             value = """
-                SELECT new com.sing4u.kr.songRequest.dto.response.SongRequestManageResponse(
+                SELECT new com.sing4u.kr.songRequest.dto.response.SongRequestManageItemDto(
                     MIN(sr.id),
                     sr.songTitle,
                     sr.songArtistName,

--- a/src/main/java/com/sing4u/kr/songRequest/repository/SongRequestRepository.java
+++ b/src/main/java/com/sing4u/kr/songRequest/repository/SongRequestRepository.java
@@ -1,7 +1,12 @@
 package com.sing4u.kr.songRequest.repository;
 
+import com.sing4u.kr.songRequest.dto.response.SongRequestManageItemDto;
 import com.sing4u.kr.songRequest.entity.SongRequest;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
@@ -9,4 +14,40 @@ import java.util.List;
 @Repository
 public interface SongRequestRepository extends JpaRepository<SongRequest, Long> {
     List<SongRequest> findBySessionIdOrderByRequestedAtAsc(Long sessionId);
+
+    // TODO: songTitle/songArtistName 표기 차이(직접 입력한 곡과 스포티파이 검색 곡 차이)로 동일 곡이 분리 집계될 수 있을 것 같아서 해결방안 생각해야 함
+    @Query(
+            value = """
+                SELECT new com.sing4u.kr.songRequest.dto.response.SongRequestManageResponse(
+                    MIN(sr.id),
+                    sr.songTitle,
+                    sr.songArtistName,
+                    COALESCE(SUM(sr.likeCount), 0),
+                    MAX(sr.albumImageUrl),
+                    COUNT(sr.id)
+                )
+                FROM SongRequest sr
+                JOIN sr.session s
+                WHERE s.artist.id = :artistId
+                  AND (
+                        :keyword IS NULL OR :keyword = '' OR
+                        LOWER(sr.songTitle) LIKE LOWER(CONCAT('%', :keyword, '%')) OR
+                        LOWER(sr.songArtistName) LIKE LOWER(CONCAT('%', :keyword, '%'))
+                      )
+                GROUP BY sr.songTitle, sr.songArtistName
+                ORDER BY COALESCE(SUM(sr.likeCount), 0) DESC, COUNT(sr.id) DESC
+            """,
+            countQuery = """
+                SELECT COUNT(DISTINCT CONCAT(sr.songTitle, '||', sr.songArtistName))
+                FROM SongRequest sr
+                JOIN sr.session s
+                WHERE s.artist.id = :artistId
+                  AND (
+                        :keyword IS NULL OR :keyword = '' OR
+                        LOWER(sr.songTitle) LIKE LOWER(CONCAT('%', :keyword, '%')) OR
+                        LOWER(sr.songArtistName) LIKE LOWER(CONCAT('%', :keyword, '%'))
+                      )
+            """
+    )
+    Page<SongRequestManageItemDto> findArtistSongRequestsForManage(@Param("artistId") Long artistId, @Param("keyword") String keyword, Pageable pageable);
 }

--- a/src/main/java/com/sing4u/kr/songRequest/service/SongRequestService.java
+++ b/src/main/java/com/sing4u/kr/songRequest/service/SongRequestService.java
@@ -3,10 +3,12 @@ package com.sing4u.kr.songRequest.service;
 
 import com.sing4u.kr.common.exception.ApiException;
 import com.sing4u.kr.common.exception.ExceptionCode;
+import com.sing4u.kr.songRequest.dto.response.SongRequestManageItemDto;
 import com.sing4u.kr.songRequest.dto.request.SongRequestCreateDto;
 import com.sing4u.kr.songRequest.dto.SongRequestResponseDto;
 import com.sing4u.kr.songRequest.dto.response.ArtistSongRequestsResponse;
 import com.sing4u.kr.songRequest.dto.response.SongDetailDto;
+import com.sing4u.kr.songRequest.dto.response.SongRequestManageResponseDto;
 import com.sing4u.kr.songRequest.entity.SongRequest;
 import com.sing4u.kr.songRequest.enums.SortType;
 import com.sing4u.kr.songRequest.repository.SongRequestRepository;
@@ -23,6 +25,8 @@ import com.sing4u.kr.user.entity.enums.UserType;
 import com.sing4u.kr.user.service.UserService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -314,6 +318,28 @@ public class SongRequestService {
                 .page(safePage)
                 .pageSize(safeSize)
                 .build();
+    }
+
+    @Transactional(readOnly = true)
+    public SongRequestManageResponseDto getArtistSongRequestsForManage(
+            Long artistId,
+            int page,
+            int pageSize,
+            String keyword
+    ) {
+        // 1) 아티스트 존재 확인
+        userRepository.findByIdAndUserTypeAndDeletedAtIsNull(artistId, UserType.ARTIST)
+                .orElseThrow(() -> new ApiException(ExceptionCode.NOT_FOUND, "아티스트를 찾을 수 없습니다. ID: " + artistId));
+
+        // 2) 페이징
+        var pageable = PageRequest.of(page, pageSize);
+
+        // 3) 집계 조회
+        Page<SongRequestManageItemDto> pageResult =
+                songRequestRepository.findArtistSongRequestsForManage(artistId, keyword, pageable);
+
+        // 4) 명세 형태로 응답 래핑
+        return SongRequestManageResponseDto.of(pageResult);
     }
 
 }

--- a/src/main/java/com/sing4u/kr/songRequest/service/SongRequestService.java
+++ b/src/main/java/com/sing4u/kr/songRequest/service/SongRequestService.java
@@ -76,8 +76,8 @@ public class SongRequestService {
                         resolvedPlatformName = trackDetails.getPlatformName();
                         albumImageUrl = trackDetails.getAlbumImageUrl();
 
-                        log.info("'{}' 플랫폼 정보로 곡 정보를 설정했습니다: '{}' - '{}' (ID: {})",
-                                resolvedPlatformName, title, artistName, resolvedPlatformTrackId);
+                        log.info("'{}' 플랫폼 정보로 곡 정보를 설정했습니다: '{}' - '{}' (ID: {}), image: {}",
+                                resolvedPlatformName, title, artistName, resolvedPlatformTrackId, albumImageUrl);
                     } else {
                         log.warn("'{}' 플랫폼에서 트랙 ID '{}'에 대한 정보를 가져오지 못했습니다. DTO에 입력된 곡 정보를 우선 사용합니다.",
                                 resolvedPlatformName, resolvedPlatformTrackId);

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -6,7 +6,7 @@ spring:
     activate:
         on-profile: dev
     import:
-        - aws-parameterstore:/config/api/application_dev/
+        - optional:aws-parameterstore:/config/api/application_${spring.profiles.active}/
 
   datasource:
     url: jdbc:mysql://${DB_HOST}:${DB_PORT}/${DB_NAME}?useSSL=false&serverTimezone=UTC&allowPublicKeyRetrieval=true

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -1,6 +1,13 @@
 spring:
   application:
     name: api
+
+  config:
+    activate:
+        on-profile: dev
+    import:
+        - aws-parameterstore:/config/api/application_dev/
+
   datasource:
     url: jdbc:mysql://${DB_HOST}:${DB_PORT}/${DB_NAME}?useSSL=false&serverTimezone=UTC&allowPublicKeyRetrieval=true
     username: ${DB_USER}

--- a/src/main/resources/application-test.yml
+++ b/src/main/resources/application-test.yml
@@ -1,4 +1,11 @@
 spring:
+  config:
+    import: ""
+
+  cloud:
+    aws:
+      enabled: false
+
   datasource:
     url: jdbc:h2:mem:testdb;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE
     driver-class-name: org.h2.Driver

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -12,9 +12,9 @@ spring:
       max-file-size: 120MB
       max-request-size: 150MB
   shutdown: graceful
-  config:
-    import:
-      - 'aws-parameterstore:/config/api/application_${spring.profiles.active}/'
+#  config:
+#    import:
+#      - optional:aws-parameterstore:/config/api/application_${spring.profiles.active}/
 
   datasource:
     driver-class-name: com.mysql.cj.jdbc.Driver
@@ -27,8 +27,8 @@ spring:
         dialect: org.hibernate.dialect.MySQL8Dialect
     open-in-view: false
 
-  profiles:
-    active: dev
+#  profiles:
+#    active: dev
 
   cache:
     jcache:

--- a/src/test/java/com/sing4u/kr/session/controller/SessionControllerTest.java
+++ b/src/test/java/com/sing4u/kr/session/controller/SessionControllerTest.java
@@ -1,0 +1,103 @@
+package com.sing4u.kr.session.controller;
+
+import com.sing4u.kr.common.response.PagingResponse;
+import com.sing4u.kr.session.dto.response.ArtistSessionResponseDto;
+import com.sing4u.kr.session.enums.SessionStatus;
+import com.sing4u.kr.session.service.SessionService;
+import com.sing4u.kr.user.repository.UserRepository;
+import com.sing4u.kr.user.service.UserService;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Sort;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@ActiveProfiles("test")
+@WebMvcTest(SessionController.class)
+@AutoConfigureMockMvc(addFilters = false)
+public class SessionControllerTest {
+
+    @Autowired
+    MockMvc mockMvc;
+
+    @MockBean
+    SessionService sessionService;
+
+    @MockBean
+    UserService userService;
+
+    @MockBean
+    UserRepository userRepository;
+
+    @Test
+    @DisplayName("아티스트 세션 관리 목록 조회 성공")
+    void getArtistSessionsForManage_success() throws Exception {
+        // given
+        String artistPublicId = "user_public_id_1";
+        Long artistId = 1L;
+
+        when(userService.getUserIdByPublicId(artistPublicId))
+                .thenReturn(artistId);
+
+        ArtistSessionResponseDto session =
+                ArtistSessionResponseDto.builder()
+                        .sessionId(1L)
+                        .status(SessionStatus.OPEN)
+                        .startedAt(LocalDateTime.of(2025, 6, 16, 10, 0))
+                        .closedAt(null)
+                        .songRequestCount(5L)
+                        .build();
+
+        Page<ArtistSessionResponseDto> pageResult =
+                new PageImpl<>(
+                        List.of(session),
+                        PageRequest.of(0, 10),
+                        1
+                );
+
+        when(sessionService.getArtistSessionsForManage(
+                artistId,
+                PageRequest.of(0, 10, Sort.by(Sort.Direction.DESC, "startedAt"))
+        )).thenReturn(pageResult);
+
+        // when & then
+        mockMvc.perform(
+                        get("/api/v1/artists/{artistPublicId}/sessions/manage", artistPublicId)
+                                .param("page", "0")
+                                .param("pageSize", "10")
+                                .accept(MediaType.APPLICATION_JSON)
+                )
+                .andExpect(jsonPath("$.content").isArray())
+                .andExpect(jsonPath("$.content.length()").value(1))
+
+                .andExpect(jsonPath("$.content[0].sessionId").value(1))
+                .andExpect(jsonPath("$.content[0].status").value("OPEN"))
+                .andExpect(jsonPath("$.content[0].songRequestCount").value(5))
+
+                .andExpect(jsonPath("$.currentPageIndex").value(0))
+                .andExpect(jsonPath("$.pageSize").value(10))
+                .andExpect(jsonPath("$.totalElements").value(1))
+                .andExpect(jsonPath("$.totalPages").value(1))
+                .andExpect(jsonPath("$.hasNext").value(false));
+
+
+    }
+
+}

--- a/src/test/java/com/sing4u/kr/songRequest/controller/SongRequestManageControllerTest.java
+++ b/src/test/java/com/sing4u/kr/songRequest/controller/SongRequestManageControllerTest.java
@@ -1,0 +1,133 @@
+package com.sing4u.kr.songRequest.controller;
+
+import com.sing4u.kr.songRequest.dto.response.SongRequestManageItemDto;
+import com.sing4u.kr.songRequest.dto.response.SongRequestManageResponseDto;
+import com.sing4u.kr.songRequest.service.SongRequestService;
+import com.sing4u.kr.user.service.UserService;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@ActiveProfiles("test")
+@WebMvcTest(SongRequestManageController.class)
+@AutoConfigureMockMvc(addFilters = false)
+public class SongRequestManageControllerTest {
+
+    @Autowired
+    MockMvc mockMvc;
+
+    @MockBean
+    SongRequestService songRequestService;
+
+    @MockBean
+    UserService userService;
+
+    @Test
+    @DisplayName("/get 아티스트 신청곡 조회(추천 데이터) 성공")
+    void getArtistSongRequestsManage_success() throws Exception {
+        String artistPublicId = "user_public_id_1";
+        Long artistId = 10L;
+
+        when(userService.getUserIdByPublicId(artistPublicId))
+                .thenReturn(artistId);
+
+        SongRequestManageItemDto item = new SongRequestManageItemDto(
+                1001L,
+                "Blue Valentine",
+                "NMIXX",
+                13L,
+                "https://i.scdn.co/image/ab67616d00",
+                4L
+        );
+
+        SongRequestManageResponseDto response =
+                SongRequestManageResponseDto.builder()
+                        .songs(List.of(item))
+                        .hasNext(false)
+                        .page(0)
+                        .pageSize(10)
+                        .totalElements(1L)
+                        .build();
+
+        when(songRequestService.getArtistSongRequestsForManage(
+                eq(artistId),
+                eq(0),
+                eq(10),
+                isNull()
+        )).thenReturn(response);
+
+        mockMvc.perform(
+                        get("/api/v1/artists/{artistPublicId}/song-requests/manage", artistPublicId)
+                                .param("page", "0")
+                                .param("pageSize", "10")
+                                .accept(MediaType.APPLICATION_JSON)
+                )
+                .andDo(print())
+                .andExpect(jsonPath("$.data.songs").isArray())
+                .andExpect(jsonPath("$.data.songs[0].songRequestId").value(1001))
+                .andExpect(jsonPath("$.data.songs[0].songTitle").value("Blue Valentine"))
+                .andExpect(jsonPath("$.data.songs[0].singer").value("NMIXX"))
+                .andExpect(jsonPath("$.data.songs[0].totalLikeCount").value(13))
+                .andExpect(jsonPath("$.data.songs[0].totalRequestCount").value(4))
+                .andExpect(jsonPath("$.data.hasNext").value(false))
+                .andExpect(jsonPath("$.data.page").value(0))
+                .andExpect(jsonPath("$.data.pageSize").value(10))
+                .andExpect(jsonPath("$.data.totalElements").value(1));
+
+    }
+
+    @Test
+    @DisplayName("/get 아티스트 신청곡 조회(추천 데이터) - keyword 포함")
+    void getArtistSongRequestsManage_withKeyword() throws Exception {
+        String artistPublicId = "user_public_id_1";
+        Long artistId = 10L;
+
+        when(userService.getUserIdByPublicId(artistPublicId))
+                .thenReturn(artistId);
+
+        SongRequestManageResponseDto response =
+                SongRequestManageResponseDto.builder()
+                        .songs(List.of())
+                        .hasNext(false)
+                        .page(0)
+                        .pageSize(10)
+                        .totalElements(0L)
+                        .build();
+
+        when(songRequestService.getArtistSongRequestsForManage(
+                eq(artistId),
+                eq(0),
+                eq(10),
+                eq("blue")
+        )).thenReturn(response);
+
+        mockMvc.perform(
+                        get("/api/v1/artists/{artistPublicId}/song-requests/manage", artistPublicId)
+                                .param("page", "0")
+                                .param("pageSize", "10")
+                                .param("keyword", "blue")
+                                .accept(MediaType.APPLICATION_JSON)
+                )
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.songs").isArray())
+                .andExpect(jsonPath("$.data.totalElements").value(0));
+
+    }
+
+}


### PR DESCRIPTION
## 🔥 개요

아티스트 추천곡 관리 페이지에서 사용하는 **신청곡 조회 API**와 **세션 조회 API**를 구현하고 테스트코드도 추가

---

## ✨ 주요 변경 사항
### 1. 아티스트용 세션 목록 조회 API 추가
- `SessionController` 수정
  - **`GET /api/v1/artists/{artistPublicId}/sessions/manage`**
  
- `ArtistSessionResponseDto` 추가
  - `songRequestCount`: 세션별 신청곡 수 합계
  
- `SessionRepository` 수정
  - `findArtistSessionsForManage`
  
- `SessionService` 수정

  - `getArtistSessionsForManage()` 메소드
 
<br>

### 2. 아티스트 추천 데이터용 신청곡 조회 API 추가
- 아티스트 관리 화면의 *추천 데이터 탭* 전용 조회 API

- `SongRequestManageController` 추가
  - **`GET /api/v1/artists/{artistPublicId}/song-requests/manage`** -> 곡 제목 / 가수명 기준 **keyword 검색 지원**
  
- `SongRequestManageItemDto`, `SongRequestManageResponseDto` 추가
  - `totalLikeCount` : 해당 곡의 총 좋아요 수
  - `totalRequestCount` : 해당 곡의 총 신청 수

- `SongRequestRepository` 수정
  - `findArtistSongRequestsForManage` -> 신청곡을 **곡 단위로 집계**하여 조회 
  
- `SongRequestService` 수정
  - `getArtistSongRequestsForManage()` 메소드

<br>

### 3. 테스트코드 추가
- `SessionControllerTest`
  - 아티스트 세션 관리 목록 조회 성공 케이스

- `SongRequestManageControllerTest`
  - 아티스트 신청곡 관리 조회 성공 케이스
  - keyword 포함 조회 케이스

- `application.yml`, `application-test.yml`, `application-dev.yml` 테스트 환경 위해 수정

---

## ⚠️ 추후 개선 예정 사항

- 현재 신청곡 집계는 **곡 제목 + 가수명 문자열 기준**으로 그룹화되어 있음
- 이로 인해,
  - 사용자가 직접 입력한 곡
  - Spotify 검색을 통해 선택한 곡  
  의 표기 차이(띄어쓰기, 특수문자, 부가 정보 등)가 있는 경우  
  **실제로 동일한 곡임에도 별도의 곡으로 분리 집계되는 이슈가 존재**
