### PR TITLE
feat: 신청곡 '불러줬어요' 처리 기능 추가

### DIFF
--- a/src/main/java/com/sing4u/kr/songRequest/controller/SongRequestManageController.java
+++ b/src/main/java/com/sing4u/kr/songRequest/controller/SongRequestManageController.java
@@ -3,6 +3,7 @@ package com.sing4u.kr.songRequest.controller;
 import com.sing4u.kr.common.dto.ResponseResult;
 import com.sing4u.kr.common.enums.ResponseCode;
 import com.sing4u.kr.songRequest.dto.response.ArtistSongRequestsResponse;
+import com.sing4u.kr.songRequest.dto.response.SongRequestCalledResponse;
 import com.sing4u.kr.songRequest.dto.response.SongRequestManageResponseDto;
 import com.sing4u.kr.songRequest.service.SongRequestService;
 import com.sing4u.kr.user.service.UserService;
@@ -35,6 +36,24 @@ public class SongRequestManageController {
 
         SongRequestManageResponseDto result =
                 songRequestService.getArtistSongRequestsForManage(artistId, page, pageSize, keyword);
+
+        return new ResponseResult<>(ResponseCode.SUCCESS, result);
+    }
+
+    @Operation(
+            summary = "신청곡 불러줬어요 처리(추천 리스트에서 제거)",
+            description = "아티스트가 신청곡을 '불러줬어요' 처리하면 추천 리스트에서 제외됩니다."
+    )
+    @PatchMapping("/artists/{artistPublicId}/song-requests/{songRequestId}/called")
+    public ResponseResult<SongRequestCalledResponse> markCalled(
+            @Parameter(description = "아티스트 공개 ID", example = "user_public_id_1")
+            @RequestParam String artistPublicId,
+            @PathVariable Long songRequestId
+    ) {
+        Long artistId = userService.getUserIdByPublicId(artistPublicId);
+
+        SongRequestCalledResponse result =
+                songRequestService.markSongRequestCalled(artistId, songRequestId);
 
         return new ResponseResult<>(ResponseCode.SUCCESS, result);
     }

--- a/src/main/java/com/sing4u/kr/songRequest/dto/response/SongRequestCalledResponse.java
+++ b/src/main/java/com/sing4u/kr/songRequest/dto/response/SongRequestCalledResponse.java
@@ -1,0 +1,11 @@
+package com.sing4u.kr.songRequest.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class SongRequestCalledResponse {
+    private Long songRequestId;
+    private String calledYn;
+}

--- a/src/main/java/com/sing4u/kr/songRequest/entity/SongRequest.java
+++ b/src/main/java/com/sing4u/kr/songRequest/entity/SongRequest.java
@@ -87,6 +87,14 @@ public class SongRequest {
     public void unmarkSaved() {
         this.savedYn = "N";
     }
+
+    @Column(name = "called_yn", length = 1, nullable = false)
+    @Builder.Default
+    private String calledYn = "N";
+
+    public void markCalled() {
+        this.calledYn = "Y";
+    }
 }
 
 

--- a/src/main/java/com/sing4u/kr/songRequest/repository/SongRequestRepository.java
+++ b/src/main/java/com/sing4u/kr/songRequest/repository/SongRequestRepository.java
@@ -12,6 +12,7 @@ import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
+import java.util.Optional;
 
 @Repository
 public interface SongRequestRepository extends JpaRepository<SongRequest, Long> {
@@ -93,36 +94,44 @@ public interface SongRequestRepository extends JpaRepository<SongRequest, Long> 
     // TODO: songTitle/songArtistName 표기 차이(직접 입력한 곡과 스포티파이 검색 곡 차이)로 동일 곡이 분리 집계될 수 있을 것 같아서 해결방안 생각해야 함
     @Query(
             value = """
-                SELECT new com.sing4u.kr.songRequest.dto.response.SongRequestManageItemDto(
-                    MIN(sr.id),
-                    sr.songTitle,
-                    sr.songArtistName,
-                    COALESCE(SUM(sr.likeCount), 0),
-                    MAX(sr.albumImageUrl),
-                    COUNT(sr.id)
-                )
-                FROM SongRequest sr
-                JOIN sr.session s
-                WHERE s.artist.id = :artistId
-                  AND (
-                        :keyword IS NULL OR :keyword = '' OR
-                        LOWER(sr.songTitle) LIKE LOWER(CONCAT('%', :keyword, '%')) OR
-                        LOWER(sr.songArtistName) LIKE LOWER(CONCAT('%', :keyword, '%'))
-                      )
-                GROUP BY sr.songTitle, sr.songArtistName
-                ORDER BY COALESCE(SUM(sr.likeCount), 0) DESC, COUNT(sr.id) DESC
-            """,
+            SELECT new com.sing4u.kr.songRequest.dto.response.SongRequestManageItemDto(
+                MIN(sr.id),
+                sr.songTitle,
+                sr.songArtistName,
+                COALESCE(SUM(sr.likeCount), 0),
+                MAX(sr.albumImageUrl),
+                COUNT(sr.id)
+            )
+            FROM SongRequest sr
+            JOIN sr.session s
+            WHERE s.artist.id = :artistId
+              AND sr.calledYn = 'N'
+              AND (
+                    :keyword IS NULL OR :keyword = '' OR
+                    LOWER(sr.songTitle) LIKE LOWER(CONCAT('%', :keyword, '%')) OR
+                    LOWER(sr.songArtistName) LIKE LOWER(CONCAT('%', :keyword, '%'))
+                  )
+            GROUP BY sr.songTitle, sr.songArtistName
+            ORDER BY COALESCE(SUM(sr.likeCount), 0) DESC, COUNT(sr.id) DESC
+        """,
             countQuery = """
-                SELECT COUNT(DISTINCT CONCAT(sr.songTitle, '||', sr.songArtistName))
-                FROM SongRequest sr
-                JOIN sr.session s
-                WHERE s.artist.id = :artistId
-                  AND (
-                        :keyword IS NULL OR :keyword = '' OR
-                        LOWER(sr.songTitle) LIKE LOWER(CONCAT('%', :keyword, '%')) OR
-                        LOWER(sr.songArtistName) LIKE LOWER(CONCAT('%', :keyword, '%'))
-                      )
-            """
+            SELECT COUNT(DISTINCT CONCAT(sr.songTitle, '||', sr.songArtistName))
+            FROM SongRequest sr
+            JOIN sr.session s
+            WHERE s.artist.id = :artistId
+              AND sr.calledYn = 'N'
+              AND (
+                    :keyword IS NULL OR :keyword = '' OR
+                    LOWER(sr.songTitle) LIKE LOWER(CONCAT('%', :keyword, '%')) OR
+                    LOWER(sr.songArtistName) LIKE LOWER(CONCAT('%', :keyword, '%'))
+                  )
+        """
     )
-    Page<SongRequestManageItemDto> findArtistSongRequestsForManage(@Param("artistId") Long artistId, @Param("keyword") String keyword, Pageable pageable);
+    Page<SongRequestManageItemDto> findArtistSongRequestsForManage(
+            @Param("artistId") Long artistId,
+            @Param("keyword") String keyword,
+            Pageable pageable
+    );
+
+    Optional<SongRequest> findByIdAndSession_Artist_Id(Long id, Long artistId);
 }

--- a/src/main/java/com/sing4u/kr/songRequest/service/SongRequestService.java
+++ b/src/main/java/com/sing4u/kr/songRequest/service/SongRequestService.java
@@ -3,12 +3,9 @@ package com.sing4u.kr.songRequest.service;
 
 import com.sing4u.kr.common.exception.ApiException;
 import com.sing4u.kr.common.exception.ExceptionCode;
-import com.sing4u.kr.songRequest.dto.response.SongRequestManageItemDto;
+import com.sing4u.kr.songRequest.dto.response.*;
 import com.sing4u.kr.songRequest.dto.request.SongRequestCreateDto;
 import com.sing4u.kr.songRequest.dto.SongRequestResponseDto;
-import com.sing4u.kr.songRequest.dto.response.ArtistSongRequestsResponse;
-import com.sing4u.kr.songRequest.dto.response.SongDetailDto;
-import com.sing4u.kr.songRequest.dto.response.SongRequestManageResponseDto;
 import com.sing4u.kr.songRequest.entity.SongRequest;
 import com.sing4u.kr.songRequest.enums.SortType;
 import com.sing4u.kr.songRequest.repository.SongRequestRepository;
@@ -248,6 +245,9 @@ public class SongRequestService {
         Stream<SongRequest> stream = sessions.stream()
                 .flatMap(session -> session.getSongRequests().stream());
 
+        // 불러준 곡 제외
+        stream = stream.filter(req -> !"Y".equals(req.getCalledYn()));
+
         // 3) sessionId 필터링
         if (sessionId != null) {
             stream = stream.filter(req -> req.getSession().getId().equals(sessionId));
@@ -358,4 +358,17 @@ public class SongRequestService {
         return SongRequestManageResponseDto.of(pageResult);
     }
 
+    @Transactional
+    public SongRequestCalledResponse markSongRequestCalled(Long artistId, Long songRequestId) {
+        SongRequest songRequest = songRequestRepository
+                .findByIdAndSession_Artist_Id(songRequestId, artistId)
+                .orElseThrow(() -> new ApiException(ExceptionCode.NOT_FOUND, "신청곡을 찾을 수 없습니다. ID: " + songRequestId));
+        // or 권한 예외로 분리해도 됨
+
+        if (!"Y".equals(songRequest.getCalledYn())) {
+            songRequest.markCalled();
+        }
+
+        return new SongRequestCalledResponse(songRequest.getId(), songRequest.getCalledYn());
+    }
 }


### PR DESCRIPTION
## ✨ 주요 변경 사항
- 신청곡 상태 관리를 위한 `calledYn` 필드 추가
  - 기본값 `N`, 불러줬어요 처리 시 `Y`
- 신청곡을 불러줬어요 처리하는 API 추가
  - 아티스트 소유 세션의 신청곡만 처리 가능하도록 검증
  - 멱등 처리 적용 (중복 호출 시에도 동일 결과 반환)
- 추천 리스트 조회 시 불러준 신청곡(`calledYn = 'Y'`) 제외
- 추천 데이터(집계) 조회 시 불러준 신청곡 제외
  - 조회 쿼리와 `countQuery` 모두 동일 조건 적용하여 페이징 일관성 유지

---

## 🔍 API 변경 사항
- `PATCH /api/v1/artists/{artistPublicId}/song-requests/{songRequestId}/called`
  - 신청곡을 `불러줬어요` 상태로 변경
  - 추천 리스트 및 추천 데이터에서 제외 처리
