### PR TITLE
feat: 아티스트 보관함(저장한 추천곡) 리스트 조회 API 추가

### DIFF
--- a/src/main/java/com/sing4u/kr/songRequest/controller/SongRequestController.java
+++ b/src/main/java/com/sing4u/kr/songRequest/controller/SongRequestController.java
@@ -76,4 +76,25 @@ public class SongRequestController {
         return new ResponseResult<>(ResponseCode.SUCCESS);
     }
 
+    @Operation(
+            summary = "아티스트 보관함 조회(저장한 신청곡 리스트)",
+            description = "아티스트가 보관(저장)한 신청곡 목록을 조회합니다. 정렬 기준의 LATEST는 '저장한 시간(savedAt)' 기준 최신순입니다. sessionId, keyword, sort(LATEST/POPULAR), page, pageSize"
+    )
+    @GetMapping("/artists/{artistPublicId}/saved")
+    public ResponseResult<ArtistSongRequestsResponse> getSavedArtistSongRequests(
+            @PathVariable String artistPublicId,
+            @RequestParam(required = false) String keyword,
+            @RequestParam(required = false, defaultValue = "LATEST") @Parameter(description = "정렬 기준", schema = @Schema(implementation = SortType.class)) SortType sort,
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "10") int pageSize
+    ) {
+
+        Long artistId = userService.getUserIdByPublicId(artistPublicId);
+
+        ArtistSongRequestsResponse result =
+                songRequestService.getSavedArtistSongRequests(artistId, keyword, sort, page, pageSize);
+
+        return new ResponseResult<>(ResponseCode.SUCCESS, result);
+    }
+
 }

--- a/src/main/java/com/sing4u/kr/songRequest/entity/SongRequest.java
+++ b/src/main/java/com/sing4u/kr/songRequest/entity/SongRequest.java
@@ -76,16 +76,22 @@ public class SongRequest {
     @Column(name = "album_image_url")
     private String albumImageUrl;
 
+
     @Column(name = "saved_yn", length = 1, nullable = false)
     @Builder.Default
     private String savedYn = "N";
 
+    @Column(name = "saved_at")
+    private LocalDateTime savedAt;
+
     public void markSaved() {
         this.savedYn = "Y";
+        this.savedAt = LocalDateTime.now();
     }
 
     public void unmarkSaved() {
         this.savedYn = "N";
+        this.savedAt = null;
     }
 
     @Column(name = "called_yn", length = 1, nullable = false)

--- a/src/main/java/com/sing4u/kr/songRequest/repository/SongRequestRepository.java
+++ b/src/main/java/com/sing4u/kr/songRequest/repository/SongRequestRepository.java
@@ -134,4 +134,40 @@ public interface SongRequestRepository extends JpaRepository<SongRequest, Long> 
     );
 
     Optional<SongRequest> findByIdAndSession_Artist_Id(Long id, Long artistId);
+
+    @Query(
+            value = """
+            SELECT DISTINCT sr FROM SongRequest sr
+            JOIN sr.session s
+            LEFT JOIN sr.tags t
+            WHERE s.artist.id = :artistId
+              AND sr.savedYn = 'Y'
+              AND sr.calledYn = 'N'
+              AND (
+                :keyword IS NULL OR :keyword = '' OR
+                LOWER(sr.songTitle) LIKE LOWER(CONCAT('%', :keyword, '%')) OR
+                LOWER(sr.songArtistName) LIKE LOWER(CONCAT('%', :keyword, '%')) OR
+                LOWER(t) LIKE LOWER(CONCAT('%', :keyword, '%'))
+              )
+        """,
+            countQuery = """
+            SELECT COUNT(DISTINCT sr.id) FROM SongRequest sr
+            JOIN sr.session s
+            LEFT JOIN sr.tags t
+            WHERE s.artist.id = :artistId
+              AND sr.savedYn = 'Y'
+              AND sr.calledYn = 'N'
+              AND (
+                :keyword IS NULL OR :keyword = '' OR
+                LOWER(sr.songTitle) LIKE LOWER(CONCAT('%', :keyword, '%')) OR
+                LOWER(sr.songArtistName) LIKE LOWER(CONCAT('%', :keyword, '%')) OR
+                LOWER(t) LIKE LOWER(CONCAT('%', :keyword, '%'))
+              )
+        """
+    )
+    Page<SongRequest> findSavedArtistSongRequests(
+            @Param("artistId") Long artistId,
+            @Param("keyword") String keyword, // sessionId 파라미터 제거됨
+            Pageable pageable
+    );
 }

--- a/src/main/java/com/sing4u/kr/songRequest/service/SongRequestService.java
+++ b/src/main/java/com/sing4u/kr/songRequest/service/SongRequestService.java
@@ -24,6 +24,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -370,5 +371,52 @@ public class SongRequestService {
         }
 
         return new SongRequestCalledResponse(songRequest.getId(), songRequest.getCalledYn());
+    }
+
+    @Transactional(readOnly = true)
+    public ArtistSongRequestsResponse getSavedArtistSongRequests(
+            Long artistId,
+            String keyword,
+            SortType sort,
+            int page,
+            int pageSize
+    ) {
+        // 1. 안전한 페이징 설정
+        int safePage = Math.max(page, 0);
+        int safeSize = Math.max(pageSize, 1);
+
+        // 2. 정렬 조건(Pageable) 생성
+        org.springframework.data.domain.Sort pageSort;
+        if (sort == SortType.POPULAR) {
+            // 인기순: 좋아요 내림차순, 동일하면 보관일시 내림차순
+            pageSort = org.springframework.data.domain.Sort.by(
+                    org.springframework.data.domain.Sort.Direction.DESC, "likeCount", "savedAt"
+            );
+        } else {
+            // 최신순: 보관일시 내림차순
+            pageSort = org.springframework.data.domain.Sort.by(
+                    org.springframework.data.domain.Sort.Direction.DESC, "savedAt"
+            );
+        }
+
+        Pageable pageable = PageRequest.of(safePage, safeSize, pageSort);
+
+        // 3. 레포지토리 조회
+        Page<SongRequest> savedPage = songRequestRepository.findSavedArtistSongRequests(
+                artistId, keyword, pageable
+        );
+
+        // 4. Entity -> DTO 변환
+        List<SongDetailDto> songDetailDtos = savedPage.getContent().stream()
+                .map(SongDetailDto::from)
+                .toList();
+
+        // 5. 응답 반환
+        return ArtistSongRequestsResponse.builder()
+                .songs(songDetailDtos)
+                .hasNext(savedPage.hasNext()) // Page 객체가 다음 페이지 존재 여부를 자동으로 알려줍니다
+                .page(safePage)
+                .pageSize(safeSize)
+                .build();
     }
 }


### PR DESCRIPTION
## 💡 작업 목적 및 배경
- 아티스트가 보관(저장)한 추천곡만 따로 모아보는 "보관함 리스트 조회" 기능 추가

## 🛠️ 주요 변경 사항

**1. `SongRequest` 엔티티 변경**
- 보관 일시를 기록하기 위해 `savedAt` 컬럼 추가
- 기존의 `markSaved()`, `unmarkSaved()` 호출 시 `savedYn` 상태와 함께 `savedAt` 시간도 업데이트/초기화 되도록 로직 보완
> **Note:** 추후  `savedYn` 이 필요없을 것 같아 리팩토링 시 `savedAt`으로 대체하고 삭제해도 될 것 같습니다.

**2. 보관함 전용 Repository 쿼리 추가**

**3. 신규 API 엔드포인트 추가**
- `GET /api/v1/songRequests/artists/{artistPublicId}/saved`
- 기존 추천곡과 동일한 DTO(`ArtistSongRequestsResponse`, `SongDetailDto`) 재사용